### PR TITLE
Remove fullstaq APT repo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,8 @@ RUN apt-get update -q \
     && apt-get install --assume-yes -q --no-install-recommends fullstaq-ruby-${RUBY_VERSION}-${RUBY_VARIANT} \
     && apt-get autoremove --assume-yes \
     && rm -rf /var/lib/apt/lists \
-    && rm -fr /var/cache/apt
+    && rm -fr /var/cache/apt \
+    && rm /etc/apt/sources.list.d/fullstaq-ruby.list
 
 ENV GEM_HOME /usr/local/bundle
 ENV BUNDLE_PATH="$GEM_HOME" \


### PR DESCRIPTION
There are sometimes issues with fullstaq apt repo I have faced with recently. Users usually don't need the updates from this repo, so it's better to remove them to prevent occasional failures.

Failures look like this:
```
E: Failed to fetch https://apt.fullstaqruby.org/dists/debian-10/InRelease  403  Forbidden
```

```
E: The repository 'https://apt.fullstaqruby.org debian-10 Release' does not have a Release file.
```

