### PR TITLE
Build Ruby 3.0.3, 2.7.5 and 2.6.9

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -17,200 +17,200 @@ jobs:
       matrix:
         include:
 
-          # 3.0.2 on Debian 11
-          - ruby-version:   "3.0.2"
+          # 3.0.3 on Debian 11
+          - ruby-version:   "3.0.3"
             ruby-variant:   "jemalloc"
             debian-image:   "bullseye"
             debian-version: "11"
-          - ruby-version:   "3.0.2"
+          - ruby-version:   "3.0.3"
             ruby-variant:   "jemalloc"
             debian-image:   "bullseye-slim"
             debian-version: "11"
-          - ruby-version:   "3.0.2"
+          - ruby-version:   "3.0.3"
             ruby-variant:   "malloctrim"
             debian-image:   "bullseye"
             debian-version: "11"
-          - ruby-version:   "3.0.2"
+          - ruby-version:   "3.0.3"
             ruby-variant:   "malloctrim"
             debian-image:   "bullseye-slim"
             debian-version: "11"
 
-          # 3.0.2 on Debian 10
-          - ruby-version:   "3.0.2"
+          # 3.0.3 on Debian 10
+          - ruby-version:   "3.0.3"
             ruby-variant:   "jemalloc"
             debian-image:   "buster"
             debian-version: "10"
             aliases:  |
-              quay.io/evl.ms/fullstaq-ruby:3.0.2-jemalloc
+              quay.io/evl.ms/fullstaq-ruby:3.0.3-jemalloc
               quay.io/evl.ms/fullstaq-ruby:3.0-jemalloc
-          - ruby-version:   "3.0.2"
+          - ruby-version:   "3.0.3"
             ruby-variant:   "jemalloc"
             debian-image:   "buster-slim"
             debian-version: "10"
             aliases: |
-              quay.io/evl.ms/fullstaq-ruby:3.0.2-jemalloc-slim
+              quay.io/evl.ms/fullstaq-ruby:3.0.3-jemalloc-slim
               quay.io/evl.ms/fullstaq-ruby:3.0-jemalloc-slim
-          - ruby-version:   "3.0.2"
+          - ruby-version:   "3.0.3"
             ruby-variant:   "malloctrim"
             debian-image:   "buster"
             debian-version: "10"
             aliases:  |
-              quay.io/evl.ms/fullstaq-ruby:3.0.2-malloctrim
+              quay.io/evl.ms/fullstaq-ruby:3.0.3-malloctrim
               quay.io/evl.ms/fullstaq-ruby:3.0-malloctrim
-          - ruby-version:   "3.0.2"
+          - ruby-version:   "3.0.3"
             ruby-variant:   "malloctrim"
             debian-image:   "buster-slim"
             debian-version: "10"
             aliases: |
-              quay.io/evl.ms/fullstaq-ruby:3.0.2-malloctrim-slim
+              quay.io/evl.ms/fullstaq-ruby:3.0.3-malloctrim-slim
               quay.io/evl.ms/fullstaq-ruby:3.0-malloctrim-slim
 
-          # 3.0.2 on Debian 9
-          - ruby-version:   "3.0.2"
+          # 3.0.3 on Debian 9
+          - ruby-version:   "3.0.3"
             ruby-variant:   "jemalloc"
             debian-image:   "stretch"
             debian-version: "9"
-          - ruby-version:   "3.0.2"
+          - ruby-version:   "3.0.3"
             ruby-variant:   "jemalloc"
             debian-image:   "stretch-slim"
             debian-version: "9"
-          - ruby-version:   "3.0.2"
+          - ruby-version:   "3.0.3"
             ruby-variant:   "malloctrim"
             debian-image:   "stretch"
             debian-version: "9"
-          - ruby-version:   "3.0.2"
+          - ruby-version:   "3.0.3"
             ruby-variant:   "malloctrim"
             debian-image:   "stretch-slim"
             debian-version: "9"
 
-          # 2.7.4 on Debian 11
-          - ruby-version:   "2.7.4"
+          # 2.7.5 on Debian 11
+          - ruby-version:   "2.7.5"
             ruby-variant:   "jemalloc"
             debian-image:   "bullseye"
             debian-version: "11"
-          - ruby-version:   "2.7.4"
+          - ruby-version:   "2.7.5"
             ruby-variant:   "jemalloc"
             debian-image:   "bullseye-slim"
             debian-version: "11"
-          - ruby-version:   "2.7.4"
+          - ruby-version:   "2.7.5"
             ruby-variant:   "malloctrim"
             debian-image:   "bullseye"
             debian-version: "11"
-          - ruby-version:   "2.7.4"
+          - ruby-version:   "2.7.5"
             ruby-variant:   "malloctrim"
             debian-image:   "bullseye-slim"
             debian-version: "11"
 
-          # 2.7.4 on Debian 10
-          - ruby-version:   "2.7.4"
+          # 2.7.5 on Debian 10
+          - ruby-version:   "2.7.5"
             ruby-variant:   "jemalloc"
             debian-image:   "buster"
             debian-version: "10"
             aliases:  |
-              quay.io/evl.ms/fullstaq-ruby:2.7.4-jemalloc
+              quay.io/evl.ms/fullstaq-ruby:2.7.5-jemalloc
               quay.io/evl.ms/fullstaq-ruby:2.7-jemalloc
-          - ruby-version:   "2.7.4"
+          - ruby-version:   "2.7.5"
             ruby-variant:   "jemalloc"
             debian-image:   "buster-slim"
             debian-version: "10"
             aliases: |
-              quay.io/evl.ms/fullstaq-ruby:2.7.4-jemalloc-slim
+              quay.io/evl.ms/fullstaq-ruby:2.7.5-jemalloc-slim
               quay.io/evl.ms/fullstaq-ruby:2.7-jemalloc-slim
-          - ruby-version:   "2.7.4"
+          - ruby-version:   "2.7.5"
             ruby-variant:   "malloctrim"
             debian-image:   "buster"
             debian-version: "10"
             aliases:  |
-              quay.io/evl.ms/fullstaq-ruby:2.7.4-malloctrim
+              quay.io/evl.ms/fullstaq-ruby:2.7.5-malloctrim
               quay.io/evl.ms/fullstaq-ruby:2.7-malloctrim
-          - ruby-version:   "2.7.4"
+          - ruby-version:   "2.7.5"
             ruby-variant:   "malloctrim"
             debian-image:   "buster-slim"
             debian-version: "10"
             aliases: |
-              quay.io/evl.ms/fullstaq-ruby:2.7.4-malloctrim-slim
+              quay.io/evl.ms/fullstaq-ruby:2.7.5-malloctrim-slim
               quay.io/evl.ms/fullstaq-ruby:2.7-malloctrim-slim
 
-          # 2.7.4 on Debian 9
-          - ruby-version:   "2.7.4"
+          # 2.7.5 on Debian 9
+          - ruby-version:   "2.7.5"
             ruby-variant:   "jemalloc"
             debian-image:   "stretch"
             debian-version: "9"
-          - ruby-version:   "2.7.4"
+          - ruby-version:   "2.7.5"
             ruby-variant:   "jemalloc"
             debian-image:   "stretch-slim"
             debian-version: "9"
-          - ruby-version:   "2.7.4"
+          - ruby-version:   "2.7.5"
             ruby-variant:   "malloctrim"
             debian-image:   "stretch"
             debian-version: "9"
-          - ruby-version:   "2.7.4"
+          - ruby-version:   "2.7.5"
             ruby-variant:   "malloctrim"
             debian-image:   "stretch-slim"
             debian-version: "9"
 
-          # 2.6.8 on Debian 11
-          - ruby-version:   "2.6.8"
+          # 2.6.9 on Debian 11
+          - ruby-version:   "2.6.9"
             ruby-variant:   "jemalloc"
             debian-image:   "bullseye"
             debian-version: "11"
-          - ruby-version:   "2.6.8"
+          - ruby-version:   "2.6.9"
             ruby-variant:   "jemalloc"
             debian-image:   "bullseye-slim"
             debian-version: "11"
-          - ruby-version:   "2.6.8"
+          - ruby-version:   "2.6.9"
             ruby-variant:   "malloctrim"
             debian-image:   "bullseye"
             debian-version: "11"
-          - ruby-version:   "2.6.8"
+          - ruby-version:   "2.6.9"
             ruby-variant:   "malloctrim"
             debian-image:   "bullseye-slim"
             debian-version: "11"
 
-          # 2.6.8 on Debian 10
-          - ruby-version:   "2.6.8"
+          # 2.6.9 on Debian 10
+          - ruby-version:   "2.6.9"
             ruby-variant:   "jemalloc"
             debian-image:   "buster"
             debian-version: "10"
             aliases:  |
-              quay.io/evl.ms/fullstaq-ruby:2.6.8-jemalloc
+              quay.io/evl.ms/fullstaq-ruby:2.6.9-jemalloc
               quay.io/evl.ms/fullstaq-ruby:2.6-jemalloc
-          - ruby-version:   "2.6.8"
+          - ruby-version:   "2.6.9"
             ruby-variant:   "jemalloc"
             debian-image:   "buster-slim"
             debian-version: "10"
             aliases: |
-              quay.io/evl.ms/fullstaq-ruby:2.6.8-jemalloc-slim
+              quay.io/evl.ms/fullstaq-ruby:2.6.9-jemalloc-slim
               quay.io/evl.ms/fullstaq-ruby:2.6-jemalloc-slim
-          - ruby-version:   "2.6.8"
+          - ruby-version:   "2.6.9"
             ruby-variant:   "malloctrim"
             debian-image:   "buster"
             debian-version: "10"
             aliases:  |
-              quay.io/evl.ms/fullstaq-ruby:2.6.8-malloctrim
+              quay.io/evl.ms/fullstaq-ruby:2.6.9-malloctrim
               quay.io/evl.ms/fullstaq-ruby:2.6-malloctrim
-          - ruby-version:   "2.6.8"
+          - ruby-version:   "2.6.9"
             ruby-variant:   "malloctrim"
             debian-image:   "buster-slim"
             debian-version: "10"
             aliases: |
-              quay.io/evl.ms/fullstaq-ruby:2.6.8-malloctrim-slim
+              quay.io/evl.ms/fullstaq-ruby:2.6.9-malloctrim-slim
               quay.io/evl.ms/fullstaq-ruby:2.6-malloctrim-slim
 
-          # 2.6.8 on Debian 9
-          - ruby-version:   "2.6.8"
+          # 2.6.9 on Debian 9
+          - ruby-version:   "2.6.9"
             ruby-variant:   "jemalloc"
             debian-image:   "stretch"
             debian-version: "9"
-          - ruby-version:   "2.6.8"
+          - ruby-version:   "2.6.9"
             ruby-variant:   "jemalloc"
             debian-image:   "stretch-slim"
             debian-version: "9"
-          - ruby-version:   "2.6.8"
+          - ruby-version:   "2.6.9"
             ruby-variant:   "malloctrim"
             debian-image:   "stretch"
             debian-version: "9"
-          - ruby-version:   "2.6.8"
+          - ruby-version:   "2.6.9"
             ruby-variant:   "malloctrim"
             debian-image:   "stretch-slim"
             debian-version: "9"

--- a/README.md
+++ b/README.md
@@ -14,72 +14,72 @@ These images are intended to be used while [Fullstaq] and [Hongli Lai] haven't b
 Pull it directly from the quay.io registry:
 
 ```sh
-docker pull quay.io/evl.ms/fullstaq-ruby:3.0.2-jemalloc-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:3.0.3-jemalloc-slim
 ```
 
 Or use as base image in your `Dockerfile`:
 
 ```docker
-ARG RUBY_VERSION=3.0.2-jemalloc
+ARG RUBY_VERSION=3.0.3-jemalloc
 
 FROM quay.io/evl.ms/fullstaq-ruby:${RUBY_VERSION}-slim
 ```
 
 ## Flavors
 
-Ruby 3.0.2, 2.7.4, and 2.6.8 with jemalloc and malloctrim are available. Images are built on top of Debian 9 (stretch), 10 (buster), and 11 (bullseye):
+Ruby 3.0.3, 2.7.5, and 2.6.9 with jemalloc and malloctrim are available. Images are built on top of Debian 9 (stretch), 10 (buster), and 11 (bullseye):
 
 ```sh
 # 3.0:
-docker pull quay.io/evl.ms/fullstaq-ruby:3.0.2-jemalloc-bullseye-slim
-docker pull quay.io/evl.ms/fullstaq-ruby:3.0.2-jemalloc-bullseye
-docker pull quay.io/evl.ms/fullstaq-ruby:3.0.2-jemalloc-buster-slim
-docker pull quay.io/evl.ms/fullstaq-ruby:3.0.2-jemalloc-buster
-docker pull quay.io/evl.ms/fullstaq-ruby:3.0.2-jemalloc-stretch-slim
-docker pull quay.io/evl.ms/fullstaq-ruby:3.0.2-jemalloc-stretch
-docker pull quay.io/evl.ms/fullstaq-ruby:3.0.2-malloctrim-bullseye-slim
-docker pull quay.io/evl.ms/fullstaq-ruby:3.0.2-malloctrim-bullseye
-docker pull quay.io/evl.ms/fullstaq-ruby:3.0.2-malloctrim-buster-slim
-docker pull quay.io/evl.ms/fullstaq-ruby:3.0.2-malloctrim-buster
-docker pull quay.io/evl.ms/fullstaq-ruby:3.0.2-malloctrim-stretch-slim
-docker pull quay.io/evl.ms/fullstaq-ruby:3.0.2-malloctrim-stretch
+docker pull quay.io/evl.ms/fullstaq-ruby:3.0.3-jemalloc-bullseye-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:3.0.3-jemalloc-bullseye
+docker pull quay.io/evl.ms/fullstaq-ruby:3.0.3-jemalloc-buster-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:3.0.3-jemalloc-buster
+docker pull quay.io/evl.ms/fullstaq-ruby:3.0.3-jemalloc-stretch-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:3.0.3-jemalloc-stretch
+docker pull quay.io/evl.ms/fullstaq-ruby:3.0.3-malloctrim-bullseye-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:3.0.3-malloctrim-bullseye
+docker pull quay.io/evl.ms/fullstaq-ruby:3.0.3-malloctrim-buster-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:3.0.3-malloctrim-buster
+docker pull quay.io/evl.ms/fullstaq-ruby:3.0.3-malloctrim-stretch-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:3.0.3-malloctrim-stretch
 
 # 2.7:
-docker pull quay.io/evl.ms/fullstaq-ruby:2.7.4-jemalloc-bullseye-slim
-docker pull quay.io/evl.ms/fullstaq-ruby:2.7.4-jemalloc-bullseye
-docker pull quay.io/evl.ms/fullstaq-ruby:2.7.4-jemalloc-buster-slim
-docker pull quay.io/evl.ms/fullstaq-ruby:2.7.4-jemalloc-buster
-docker pull quay.io/evl.ms/fullstaq-ruby:2.7.4-jemalloc-stretch-slim
-docker pull quay.io/evl.ms/fullstaq-ruby:2.7.4-jemalloc-stretch
-docker pull quay.io/evl.ms/fullstaq-ruby:2.7.4-malloctrim-bullseye-slim
-docker pull quay.io/evl.ms/fullstaq-ruby:2.7.4-malloctrim-bullseye
-docker pull quay.io/evl.ms/fullstaq-ruby:2.7.4-malloctrim-buster-slim
-docker pull quay.io/evl.ms/fullstaq-ruby:2.7.4-malloctrim-buster
-docker pull quay.io/evl.ms/fullstaq-ruby:2.7.4-malloctrim-stretch-slim
-docker pull quay.io/evl.ms/fullstaq-ruby:2.7.4-malloctrim-stretch
+docker pull quay.io/evl.ms/fullstaq-ruby:2.7.5-jemalloc-bullseye-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:2.7.5-jemalloc-bullseye
+docker pull quay.io/evl.ms/fullstaq-ruby:2.7.5-jemalloc-buster-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:2.7.5-jemalloc-buster
+docker pull quay.io/evl.ms/fullstaq-ruby:2.7.5-jemalloc-stretch-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:2.7.5-jemalloc-stretch
+docker pull quay.io/evl.ms/fullstaq-ruby:2.7.5-malloctrim-bullseye-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:2.7.5-malloctrim-bullseye
+docker pull quay.io/evl.ms/fullstaq-ruby:2.7.5-malloctrim-buster-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:2.7.5-malloctrim-buster
+docker pull quay.io/evl.ms/fullstaq-ruby:2.7.5-malloctrim-stretch-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:2.7.5-malloctrim-stretch
 
 # 2.6:
-docker pull quay.io/evl.ms/fullstaq-ruby:2.6.8-jemalloc-bullseye-slim
-docker pull quay.io/evl.ms/fullstaq-ruby:2.6.8-jemalloc-bullseye
-docker pull quay.io/evl.ms/fullstaq-ruby:2.6.8-jemalloc-buster-slim
-docker pull quay.io/evl.ms/fullstaq-ruby:2.6.8-jemalloc-buster
-docker pull quay.io/evl.ms/fullstaq-ruby:2.6.8-jemalloc-stretch-slim
-docker pull quay.io/evl.ms/fullstaq-ruby:2.6.8-jemalloc-stretch
-docker pull quay.io/evl.ms/fullstaq-ruby:2.6.8-malloctrim-bullseye-slim
-docker pull quay.io/evl.ms/fullstaq-ruby:2.6.8-malloctrim-bullseye
-docker pull quay.io/evl.ms/fullstaq-ruby:2.6.8-malloctrim-buster-slim
-docker pull quay.io/evl.ms/fullstaq-ruby:2.6.8-malloctrim-buster
-docker pull quay.io/evl.ms/fullstaq-ruby:2.6.8-malloctrim-stretch-slim
-docker pull quay.io/evl.ms/fullstaq-ruby:2.6.8-malloctrim-stretch
+docker pull quay.io/evl.ms/fullstaq-ruby:2.6.9-jemalloc-bullseye-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:2.6.9-jemalloc-bullseye
+docker pull quay.io/evl.ms/fullstaq-ruby:2.6.9-jemalloc-buster-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:2.6.9-jemalloc-buster
+docker pull quay.io/evl.ms/fullstaq-ruby:2.6.9-jemalloc-stretch-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:2.6.9-jemalloc-stretch
+docker pull quay.io/evl.ms/fullstaq-ruby:2.6.9-malloctrim-bullseye-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:2.6.9-malloctrim-bullseye
+docker pull quay.io/evl.ms/fullstaq-ruby:2.6.9-malloctrim-buster-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:2.6.9-malloctrim-buster
+docker pull quay.io/evl.ms/fullstaq-ruby:2.6.9-malloctrim-stretch-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:2.6.9-malloctrim-stretch
 ```
 
-Latest patch versions on Debian 10 (buster) are also aliased with shortened tags including major and minor versions only: `3.0.2-jemalloc-buster → 3.0-jemalloc`
+Latest patch versions on Debian 10 (buster) are also aliased with shortened tags including major and minor versions only: `3.0.3-jemalloc-buster → 3.0-jemalloc`
 
 ```sh
-docker pull quay.io/evl.ms/fullstaq-ruby:3.0-jemalloc-slim   # Same as quay.io/evl.ms/fullstaq-ruby:3.0.2-jemalloc-buster-slim
-docker pull quay.io/evl.ms/fullstaq-ruby:3.0-jemalloc        # Same as quay.io/evl.ms/fullstaq-ruby:3.0.2-jemalloc-buster
-docker pull quay.io/evl.ms/fullstaq-ruby:3.0-malloctrim-slim # Same as quay.io/evl.ms/fullstaq-ruby:3.0.2-malloctrim-buster-slim
-docker pull quay.io/evl.ms/fullstaq-ruby:3.0-malloctrim      # Same as quay.io/evl.ms/fullstaq-ruby:3.0.2-malloctrim-buster
+docker pull quay.io/evl.ms/fullstaq-ruby:3.0-jemalloc-slim   # Same as quay.io/evl.ms/fullstaq-ruby:3.0.3-jemalloc-buster-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:3.0-jemalloc        # Same as quay.io/evl.ms/fullstaq-ruby:3.0.3-jemalloc-buster
+docker pull quay.io/evl.ms/fullstaq-ruby:3.0-malloctrim-slim # Same as quay.io/evl.ms/fullstaq-ruby:3.0.3-malloctrim-buster-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:3.0-malloctrim      # Same as quay.io/evl.ms/fullstaq-ruby:3.0.3-malloctrim-buster
 ```
 
 ## Details


### PR DESCRIPTION
See official announcements for details:

 - https://www.ruby-lang.org/en/news/2021/11/24/ruby-3-0-3-released/
 - https://www.ruby-lang.org/en/news/2021/11/24/ruby-2-7-5-released/
 - https://www.ruby-lang.org/en/news/2021/11/24/ruby-2-6-9-released/

Closes #15 