### PR TITLE
Bump Ruby patch version to 3.2.1

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -17,68 +17,68 @@ jobs:
       matrix:
         include:
 
-          # 3.2.0 on Debian 11
-          - ruby-version:   "3.2.0"
+          # 3.2.1 on Debian 11
+          - ruby-version:   "3.2.1"
             ruby-variant:   "jemalloc"
             debian-image:   "bullseye"
             debian-version: "11"
             aliases:  |
-              quay.io/evl.ms/fullstaq-ruby:3.2.0-jemalloc
+              quay.io/evl.ms/fullstaq-ruby:3.2.1-jemalloc
               quay.io/evl.ms/fullstaq-ruby:3.2-jemalloc
-          - ruby-version:   "3.2.0"
+          - ruby-version:   "3.2.1"
             ruby-variant:   "jemalloc"
             debian-image:   "bullseye-slim"
             debian-version: "11"
             aliases: |
-              quay.io/evl.ms/fullstaq-ruby:3.2.0-jemalloc-slim
+              quay.io/evl.ms/fullstaq-ruby:3.2.1-jemalloc-slim
               quay.io/evl.ms/fullstaq-ruby:3.2-jemalloc-slim
-          - ruby-version:   "3.2.0"
+          - ruby-version:   "3.2.1"
             ruby-variant:   "malloctrim"
             debian-image:   "bullseye"
             debian-version: "11"
             aliases:  |
-              quay.io/evl.ms/fullstaq-ruby:3.2.0-malloctrim
+              quay.io/evl.ms/fullstaq-ruby:3.2.1-malloctrim
               quay.io/evl.ms/fullstaq-ruby:3.2-malloctrim
-          - ruby-version:   "3.2.0"
+          - ruby-version:   "3.2.1"
             ruby-variant:   "malloctrim"
             debian-image:   "bullseye-slim"
             debian-version: "11"
             aliases: |
-              quay.io/evl.ms/fullstaq-ruby:3.2.0-malloctrim-slim
+              quay.io/evl.ms/fullstaq-ruby:3.2.1-malloctrim-slim
               quay.io/evl.ms/fullstaq-ruby:3.2-malloctrim-slim
 
-          # 3.2.0 on Debian 10
-          - ruby-version:   "3.2.0"
+          # 3.2.1 on Debian 10
+          - ruby-version:   "3.2.1"
             ruby-variant:   "jemalloc"
             debian-image:   "buster"
             debian-version: "10"
-          - ruby-version:   "3.2.0"
+          - ruby-version:   "3.2.1"
             ruby-variant:   "jemalloc"
             debian-image:   "buster-slim"
             debian-version: "10"
-          - ruby-version:   "3.2.0"
+          - ruby-version:   "3.2.1"
             ruby-variant:   "malloctrim"
             debian-image:   "buster"
             debian-version: "10"
-          - ruby-version:   "3.2.0"
+          - ruby-version:   "3.2.1"
             ruby-variant:   "malloctrim"
             debian-image:   "buster-slim"
             debian-version: "10"
 
-          # 3.2.0 on Debian 9
-          - ruby-version:   "3.2.0"
+          # 3.2.1 on Debian 9
+          - ruby-version:   "3.2.1"
             ruby-variant:   "jemalloc"
             debian-image:   "stretch"
             debian-version: "9"
-          - ruby-version:   "3.2.0"
+          - ruby-version:   "3.2.1"
             ruby-variant:   "jemalloc"
             debian-image:   "stretch-slim"
             debian-version: "9"
-          - ruby-version:   "3.2.0"
+          - ruby-version:   "3.2.1"
             ruby-variant:   "malloctrim"
             debian-image:   "stretch"
             debian-version: "9"
-          - ruby-version:   "3.2.0"
+          - ruby-version:   "3.2.1"
             ruby-variant:   "malloctrim"
             debian-image:   "stretch-slim"
             debian-version: "9"

--- a/README.md
+++ b/README.md
@@ -20,29 +20,29 @@ docker pull quay.io/evl.ms/fullstaq-ruby:3.1-jemalloc-slim
 Or use as base image in your `Dockerfile`:
 
 ```docker
-ARG RUBY_VERSION=3.2.0-jemalloc
+ARG RUBY_VERSION=3.2.1-jemalloc
 
 FROM quay.io/evl.ms/fullstaq-ruby:${RUBY_VERSION}-slim
 ```
 
 ## Flavors
 
-Ruby 3.2.0, 3.1.3, 3.0.5, and 2.7.7 with jemalloc and malloctrim are available. Images are built on top of Debian 9 (stretch), 10 (buster), and 11 (bullseye):
+Ruby 3.2.1, 3.1.3, 3.0.5, and 2.7.7 with jemalloc and malloctrim are available. Images are built on top of Debian 9 (stretch), 10 (buster), and 11 (bullseye):
 
 ```sh
 # 3.2:
-docker pull quay.io/evl.ms/fullstaq-ruby:3.2.0-jemalloc-bullseye-slim
-docker pull quay.io/evl.ms/fullstaq-ruby:3.2.0-jemalloc-bullseye
-docker pull quay.io/evl.ms/fullstaq-ruby:3.2.0-jemalloc-buster-slim
-docker pull quay.io/evl.ms/fullstaq-ruby:3.2.0-jemalloc-buster
-docker pull quay.io/evl.ms/fullstaq-ruby:3.2.0-jemalloc-stretch-slim
-docker pull quay.io/evl.ms/fullstaq-ruby:3.2.0-jemalloc-stretch
-docker pull quay.io/evl.ms/fullstaq-ruby:3.2.0-malloctrim-bullseye-slim
-docker pull quay.io/evl.ms/fullstaq-ruby:3.2.0-malloctrim-bullseye
-docker pull quay.io/evl.ms/fullstaq-ruby:3.2.0-malloctrim-buster-slim
-docker pull quay.io/evl.ms/fullstaq-ruby:3.2.0-malloctrim-buster
-docker pull quay.io/evl.ms/fullstaq-ruby:3.2.0-malloctrim-stretch-slim
-docker pull quay.io/evl.ms/fullstaq-ruby:3.2.0-malloctrim-stretch
+docker pull quay.io/evl.ms/fullstaq-ruby:3.2.1-jemalloc-bullseye-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:3.2.1-jemalloc-bullseye
+docker pull quay.io/evl.ms/fullstaq-ruby:3.2.1-jemalloc-buster-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:3.2.1-jemalloc-buster
+docker pull quay.io/evl.ms/fullstaq-ruby:3.2.1-jemalloc-stretch-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:3.2.1-jemalloc-stretch
+docker pull quay.io/evl.ms/fullstaq-ruby:3.2.1-malloctrim-bullseye-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:3.2.1-malloctrim-bullseye
+docker pull quay.io/evl.ms/fullstaq-ruby:3.2.1-malloctrim-buster-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:3.2.1-malloctrim-buster
+docker pull quay.io/evl.ms/fullstaq-ruby:3.2.1-malloctrim-stretch-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:3.2.1-malloctrim-stretch
 
 # 3.1:
 docker pull quay.io/evl.ms/fullstaq-ruby:3.1.3-jemalloc-bullseye-slim
@@ -87,7 +87,7 @@ docker pull quay.io/evl.ms/fullstaq-ruby:2.7.7-malloctrim-stretch-slim
 docker pull quay.io/evl.ms/fullstaq-ruby:2.7.7-malloctrim-stretch
 ```
 
-Latest patch versions for Ruby 3.2 on Debian 11 (bullseye) are also aliased with shortened tags including major and minor versions only: `3.2.0-jemalloc-bullseye → 3.2-jemalloc`
+Latest patch versions for Ruby 3.2 on Debian 11 (bullseye) are also aliased with shortened tags including major and minor versions only: `3.2.1-jemalloc-bullseye → 3.2-jemalloc`
 
 ```sh
 docker pull quay.io/evl.ms/fullstaq-ruby:3.2-jemalloc-slim   # Same as quay.io/evl.ms/fullstaq-ruby:3.2.3-jemalloc-bullseye-slim


### PR DESCRIPTION
Official Release:
* https://www.ruby-lang.org/en/news/2023/02/08/ruby-3-2-1-released/