### PR TITLE
Add ruby 3.2.2, 3.1.4, 3.0.6 and 2.7.8

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -83,68 +83,68 @@ jobs:
             debian-image:   "stretch-slim"
             debian-version: "9"
 
-          # 3.1.3 on Debian 11
-          - ruby-version:   "3.1.3"
+          # 3.1.4 on Debian 11
+          - ruby-version:   "3.1.4"
             ruby-variant:   "jemalloc"
             debian-image:   "bullseye"
             debian-version: "11"
             aliases:  |
-              quay.io/evl.ms/fullstaq-ruby:3.1.3-jemalloc
+              quay.io/evl.ms/fullstaq-ruby:3.1.4-jemalloc
               quay.io/evl.ms/fullstaq-ruby:3.1-jemalloc
-          - ruby-version:   "3.1.3"
+          - ruby-version:   "3.1.4"
             ruby-variant:   "jemalloc"
             debian-image:   "bullseye-slim"
             debian-version: "11"
             aliases: |
-              quay.io/evl.ms/fullstaq-ruby:3.1.3-jemalloc-slim
+              quay.io/evl.ms/fullstaq-ruby:3.1.4-jemalloc-slim
               quay.io/evl.ms/fullstaq-ruby:3.1-jemalloc-slim
-          - ruby-version:   "3.1.3"
+          - ruby-version:   "3.1.4"
             ruby-variant:   "malloctrim"
             debian-image:   "bullseye"
             debian-version: "11"
             aliases:  |
-              quay.io/evl.ms/fullstaq-ruby:3.1.3-malloctrim
+              quay.io/evl.ms/fullstaq-ruby:3.1.4-malloctrim
               quay.io/evl.ms/fullstaq-ruby:3.1-malloctrim
-          - ruby-version:   "3.1.3"
+          - ruby-version:   "3.1.4"
             ruby-variant:   "malloctrim"
             debian-image:   "bullseye-slim"
             debian-version: "11"
             aliases: |
-              quay.io/evl.ms/fullstaq-ruby:3.1.3-malloctrim-slim
+              quay.io/evl.ms/fullstaq-ruby:3.1.4-malloctrim-slim
               quay.io/evl.ms/fullstaq-ruby:3.1-malloctrim-slim
 
-          # 3.1.3 on Debian 10
-          - ruby-version:   "3.1.3"
+          # 3.1.4 on Debian 10
+          - ruby-version:   "3.1.4"
             ruby-variant:   "jemalloc"
             debian-image:   "buster"
             debian-version: "10"
-          - ruby-version:   "3.1.3"
+          - ruby-version:   "3.1.4"
             ruby-variant:   "jemalloc"
             debian-image:   "buster-slim"
             debian-version: "10"
-          - ruby-version:   "3.1.3"
+          - ruby-version:   "3.1.4"
             ruby-variant:   "malloctrim"
             debian-image:   "buster"
             debian-version: "10"
-          - ruby-version:   "3.1.3"
+          - ruby-version:   "3.1.4"
             ruby-variant:   "malloctrim"
             debian-image:   "buster-slim"
             debian-version: "10"
 
-          # 3.1.3 on Debian 9
-          - ruby-version:   "3.1.3"
+          # 3.1.4 on Debian 9
+          - ruby-version:   "3.1.4"
             ruby-variant:   "jemalloc"
             debian-image:   "stretch"
             debian-version: "9"
-          - ruby-version:   "3.1.3"
+          - ruby-version:   "3.1.4"
             ruby-variant:   "jemalloc"
             debian-image:   "stretch-slim"
             debian-version: "9"
-          - ruby-version:   "3.1.3"
+          - ruby-version:   "3.1.4"
             ruby-variant:   "malloctrim"
             debian-image:   "stretch"
             debian-version: "9"
-          - ruby-version:   "3.1.3"
+          - ruby-version:   "3.1.4"
             ruby-variant:   "malloctrim"
             debian-image:   "stretch-slim"
             debian-version: "9"

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -149,68 +149,68 @@ jobs:
             debian-image:   "stretch-slim"
             debian-version: "9"
 
-          # 3.0.5 on Debian 11
-          - ruby-version:   "3.0.5"
+          # 3.0.6 on Debian 11
+          - ruby-version:   "3.0.6"
             ruby-variant:   "jemalloc"
             debian-image:   "bullseye"
             debian-version: "11"
-          - ruby-version:   "3.0.5"
+          - ruby-version:   "3.0.6"
             ruby-variant:   "jemalloc"
             debian-image:   "bullseye-slim"
             debian-version: "11"
-          - ruby-version:   "3.0.5"
+          - ruby-version:   "3.0.6"
             ruby-variant:   "malloctrim"
             debian-image:   "bullseye"
             debian-version: "11"
-          - ruby-version:   "3.0.5"
+          - ruby-version:   "3.0.6"
             ruby-variant:   "malloctrim"
             debian-image:   "bullseye-slim"
             debian-version: "11"
 
-          # 3.0.5 on Debian 10
-          - ruby-version:   "3.0.5"
+          # 3.0.6 on Debian 10
+          - ruby-version:   "3.0.6"
             ruby-variant:   "jemalloc"
             debian-image:   "buster"
             debian-version: "10"
             aliases:  |
-              quay.io/evl.ms/fullstaq-ruby:3.0.5-jemalloc
+              quay.io/evl.ms/fullstaq-ruby:3.0.6-jemalloc
               quay.io/evl.ms/fullstaq-ruby:3.0-jemalloc
-          - ruby-version:   "3.0.5"
+          - ruby-version:   "3.0.6"
             ruby-variant:   "jemalloc"
             debian-image:   "buster-slim"
             debian-version: "10"
             aliases: |
-              quay.io/evl.ms/fullstaq-ruby:3.0.5-jemalloc-slim
+              quay.io/evl.ms/fullstaq-ruby:3.0.6-jemalloc-slim
               quay.io/evl.ms/fullstaq-ruby:3.0-jemalloc-slim
-          - ruby-version:   "3.0.5"
+          - ruby-version:   "3.0.6"
             ruby-variant:   "malloctrim"
             debian-image:   "buster"
             debian-version: "10"
             aliases:  |
-              quay.io/evl.ms/fullstaq-ruby:3.0.5-malloctrim
+              quay.io/evl.ms/fullstaq-ruby:3.0.6-malloctrim
               quay.io/evl.ms/fullstaq-ruby:3.0-malloctrim
-          - ruby-version:   "3.0.5"
+          - ruby-version:   "3.0.6"
             ruby-variant:   "malloctrim"
             debian-image:   "buster-slim"
             debian-version: "10"
             aliases: |
-              quay.io/evl.ms/fullstaq-ruby:3.0.5-malloctrim-slim
+              quay.io/evl.ms/fullstaq-ruby:3.0.6-malloctrim-slim
               quay.io/evl.ms/fullstaq-ruby:3.0-malloctrim-slim
 
-          # 3.0.5 on Debian 9
-          - ruby-version:   "3.0.5"
+          # 3.0.6 on Debian 9
+          - ruby-version:   "3.0.6"
             ruby-variant:   "jemalloc"
             debian-image:   "stretch"
             debian-version: "9"
-          - ruby-version:   "3.0.5"
+          - ruby-version:   "3.0.6"
             ruby-variant:   "jemalloc"
             debian-image:   "stretch-slim"
             debian-version: "9"
-          - ruby-version:   "3.0.5"
+          - ruby-version:   "3.0.6"
             ruby-variant:   "malloctrim"
             debian-image:   "stretch"
             debian-version: "9"
-          - ruby-version:   "3.0.5"
+          - ruby-version:   "3.0.6"
             ruby-variant:   "malloctrim"
             debian-image:   "stretch-slim"
             debian-version: "9"

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -215,68 +215,68 @@ jobs:
             debian-image:   "stretch-slim"
             debian-version: "9"
 
-          # 2.7.7 on Debian 11
-          - ruby-version:   "2.7.7"
+          # 2.7.8 on Debian 11
+          - ruby-version:   "2.7.8"
             ruby-variant:   "jemalloc"
             debian-image:   "bullseye"
             debian-version: "11"
-          - ruby-version:   "2.7.7"
+          - ruby-version:   "2.7.8"
             ruby-variant:   "jemalloc"
             debian-image:   "bullseye-slim"
             debian-version: "11"
-          - ruby-version:   "2.7.7"
+          - ruby-version:   "2.7.8"
             ruby-variant:   "malloctrim"
             debian-image:   "bullseye"
             debian-version: "11"
-          - ruby-version:   "2.7.7"
+          - ruby-version:   "2.7.8"
             ruby-variant:   "malloctrim"
             debian-image:   "bullseye-slim"
             debian-version: "11"
 
-          # 2.7.7 on Debian 10
-          - ruby-version:   "2.7.7"
+          # 2.7.8 on Debian 10
+          - ruby-version:   "2.7.8"
             ruby-variant:   "jemalloc"
             debian-image:   "buster"
             debian-version: "10"
             aliases:  |
-              quay.io/evl.ms/fullstaq-ruby:2.7.7-jemalloc
+              quay.io/evl.ms/fullstaq-ruby:2.7.8-jemalloc
               quay.io/evl.ms/fullstaq-ruby:2.7-jemalloc
-          - ruby-version:   "2.7.7"
+          - ruby-version:   "2.7.8"
             ruby-variant:   "jemalloc"
             debian-image:   "buster-slim"
             debian-version: "10"
             aliases: |
-              quay.io/evl.ms/fullstaq-ruby:2.7.7-jemalloc-slim
+              quay.io/evl.ms/fullstaq-ruby:2.7.8-jemalloc-slim
               quay.io/evl.ms/fullstaq-ruby:2.7-jemalloc-slim
-          - ruby-version:   "2.7.7"
+          - ruby-version:   "2.7.8"
             ruby-variant:   "malloctrim"
             debian-image:   "buster"
             debian-version: "10"
             aliases:  |
-              quay.io/evl.ms/fullstaq-ruby:2.7.7-malloctrim
+              quay.io/evl.ms/fullstaq-ruby:2.7.8-malloctrim
               quay.io/evl.ms/fullstaq-ruby:2.7-malloctrim
-          - ruby-version:   "2.7.7"
+          - ruby-version:   "2.7.8"
             ruby-variant:   "malloctrim"
             debian-image:   "buster-slim"
             debian-version: "10"
             aliases: |
-              quay.io/evl.ms/fullstaq-ruby:2.7.7-malloctrim-slim
+              quay.io/evl.ms/fullstaq-ruby:2.7.8-malloctrim-slim
               quay.io/evl.ms/fullstaq-ruby:2.7-malloctrim-slim
 
-          # 2.7.7 on Debian 9
-          - ruby-version:   "2.7.7"
+          # 2.7.8 on Debian 9
+          - ruby-version:   "2.7.8"
             ruby-variant:   "jemalloc"
             debian-image:   "stretch"
             debian-version: "9"
-          - ruby-version:   "2.7.7"
+          - ruby-version:   "2.7.8"
             ruby-variant:   "jemalloc"
             debian-image:   "stretch-slim"
             debian-version: "9"
-          - ruby-version:   "2.7.7"
+          - ruby-version:   "2.7.8"
             ruby-variant:   "malloctrim"
             debian-image:   "stretch"
             debian-version: "9"
-          - ruby-version:   "2.7.7"
+          - ruby-version:   "2.7.8"
             ruby-variant:   "malloctrim"
             debian-image:   "stretch-slim"
             debian-version: "9"

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -17,68 +17,68 @@ jobs:
       matrix:
         include:
 
-          # 3.2.1 on Debian 11
-          - ruby-version:   "3.2.1"
+          # 3.2.2 on Debian 11
+          - ruby-version:   "3.2.2"
             ruby-variant:   "jemalloc"
             debian-image:   "bullseye"
             debian-version: "11"
             aliases:  |
-              quay.io/evl.ms/fullstaq-ruby:3.2.1-jemalloc
+              quay.io/evl.ms/fullstaq-ruby:3.2.2-jemalloc
               quay.io/evl.ms/fullstaq-ruby:3.2-jemalloc
-          - ruby-version:   "3.2.1"
+          - ruby-version:   "3.2.2"
             ruby-variant:   "jemalloc"
             debian-image:   "bullseye-slim"
             debian-version: "11"
             aliases: |
-              quay.io/evl.ms/fullstaq-ruby:3.2.1-jemalloc-slim
+              quay.io/evl.ms/fullstaq-ruby:3.2.2-jemalloc-slim
               quay.io/evl.ms/fullstaq-ruby:3.2-jemalloc-slim
-          - ruby-version:   "3.2.1"
+          - ruby-version:   "3.2.2"
             ruby-variant:   "malloctrim"
             debian-image:   "bullseye"
             debian-version: "11"
             aliases:  |
-              quay.io/evl.ms/fullstaq-ruby:3.2.1-malloctrim
+              quay.io/evl.ms/fullstaq-ruby:3.2.2-malloctrim
               quay.io/evl.ms/fullstaq-ruby:3.2-malloctrim
-          - ruby-version:   "3.2.1"
+          - ruby-version:   "3.2.2"
             ruby-variant:   "malloctrim"
             debian-image:   "bullseye-slim"
             debian-version: "11"
             aliases: |
-              quay.io/evl.ms/fullstaq-ruby:3.2.1-malloctrim-slim
+              quay.io/evl.ms/fullstaq-ruby:3.2.2-malloctrim-slim
               quay.io/evl.ms/fullstaq-ruby:3.2-malloctrim-slim
 
-          # 3.2.1 on Debian 10
-          - ruby-version:   "3.2.1"
+          # 3.2.2 on Debian 10
+          - ruby-version:   "3.2.2"
             ruby-variant:   "jemalloc"
             debian-image:   "buster"
             debian-version: "10"
-          - ruby-version:   "3.2.1"
+          - ruby-version:   "3.2.2"
             ruby-variant:   "jemalloc"
             debian-image:   "buster-slim"
             debian-version: "10"
-          - ruby-version:   "3.2.1"
+          - ruby-version:   "3.2.2"
             ruby-variant:   "malloctrim"
             debian-image:   "buster"
             debian-version: "10"
-          - ruby-version:   "3.2.1"
+          - ruby-version:   "3.2.2"
             ruby-variant:   "malloctrim"
             debian-image:   "buster-slim"
             debian-version: "10"
 
-          # 3.2.1 on Debian 9
-          - ruby-version:   "3.2.1"
+          # 3.2.2 on Debian 9
+          - ruby-version:   "3.2.2"
             ruby-variant:   "jemalloc"
             debian-image:   "stretch"
             debian-version: "9"
-          - ruby-version:   "3.2.1"
+          - ruby-version:   "3.2.2"
             ruby-variant:   "jemalloc"
             debian-image:   "stretch-slim"
             debian-version: "9"
-          - ruby-version:   "3.2.1"
+          - ruby-version:   "3.2.2"
             ruby-variant:   "malloctrim"
             debian-image:   "stretch"
             debian-version: "9"
-          - ruby-version:   "3.2.1"
+          - ruby-version:   "3.2.2"
             ruby-variant:   "malloctrim"
             debian-image:   "stretch-slim"
             debian-version: "9"

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ FROM quay.io/evl.ms/fullstaq-ruby:${RUBY_VERSION}-slim
 
 ## Flavors
 
-Ruby 3.2.2, 3.1.4, 3.0.5, and 2.7.7 with jemalloc and malloctrim are available. Images are built on top of Debian 9 (stretch), 10 (buster), and 11 (bullseye):
+Ruby 3.2.2, 3.1.4, 3.0.6, and 2.7.7 with jemalloc and malloctrim are available. Images are built on top of Debian 9 (stretch), 10 (buster), and 11 (bullseye):
 
 ```sh
 # 3.2:
@@ -59,18 +59,18 @@ docker pull quay.io/evl.ms/fullstaq-ruby:3.1.4-malloctrim-stretch-slim
 docker pull quay.io/evl.ms/fullstaq-ruby:3.1.4-malloctrim-stretch
 
 # 3.0:
-docker pull quay.io/evl.ms/fullstaq-ruby:3.0.5-jemalloc-bullseye-slim
-docker pull quay.io/evl.ms/fullstaq-ruby:3.0.5-jemalloc-bullseye
-docker pull quay.io/evl.ms/fullstaq-ruby:3.0.5-jemalloc-buster-slim
-docker pull quay.io/evl.ms/fullstaq-ruby:3.0.5-jemalloc-buster
-docker pull quay.io/evl.ms/fullstaq-ruby:3.0.5-jemalloc-stretch-slim
-docker pull quay.io/evl.ms/fullstaq-ruby:3.0.5-jemalloc-stretch
-docker pull quay.io/evl.ms/fullstaq-ruby:3.0.5-malloctrim-bullseye-slim
-docker pull quay.io/evl.ms/fullstaq-ruby:3.0.5-malloctrim-bullseye
-docker pull quay.io/evl.ms/fullstaq-ruby:3.0.5-malloctrim-buster-slim
-docker pull quay.io/evl.ms/fullstaq-ruby:3.0.5-malloctrim-buster
-docker pull quay.io/evl.ms/fullstaq-ruby:3.0.5-malloctrim-stretch-slim
-docker pull quay.io/evl.ms/fullstaq-ruby:3.0.5-malloctrim-stretch
+docker pull quay.io/evl.ms/fullstaq-ruby:3.0.6-jemalloc-bullseye-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:3.0.6-jemalloc-bullseye
+docker pull quay.io/evl.ms/fullstaq-ruby:3.0.6-jemalloc-buster-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:3.0.6-jemalloc-buster
+docker pull quay.io/evl.ms/fullstaq-ruby:3.0.6-jemalloc-stretch-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:3.0.6-jemalloc-stretch
+docker pull quay.io/evl.ms/fullstaq-ruby:3.0.6-malloctrim-bullseye-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:3.0.6-malloctrim-bullseye
+docker pull quay.io/evl.ms/fullstaq-ruby:3.0.6-malloctrim-buster-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:3.0.6-malloctrim-buster
+docker pull quay.io/evl.ms/fullstaq-ruby:3.0.6-malloctrim-stretch-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:3.0.6-malloctrim-stretch
 
 # 2.7:
 docker pull quay.io/evl.ms/fullstaq-ruby:2.7.7-jemalloc-bullseye-slim
@@ -96,7 +96,7 @@ docker pull quay.io/evl.ms/fullstaq-ruby:3.2-malloctrim-slim # Same as quay.io/e
 docker pull quay.io/evl.ms/fullstaq-ruby:3.2-malloctrim      # Same as quay.io/evl.ms/fullstaq-ruby:3.2.3-malloctrim-bullseye
 ```
 
-For Ruby 3.0 and older, short aliases for latest patch versions are made against Debian 10 (buster): `3.0.5-jemalloc-buster → 3.0-jemalloc`
+For Ruby 3.0 and older, short aliases for latest patch versions are made against Debian 10 (buster): `3.0.6-jemalloc-buster → 3.0-jemalloc`
 
 
 ## Details

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ FROM quay.io/evl.ms/fullstaq-ruby:${RUBY_VERSION}-slim
 
 ## Flavors
 
-Ruby 3.2.2, 3.1.4, 3.0.6, and 2.7.7 with jemalloc and malloctrim are available. Images are built on top of Debian 9 (stretch), 10 (buster), and 11 (bullseye):
+Ruby 3.2.2, 3.1.4, 3.0.6, and 2.7.8 with jemalloc and malloctrim are available. Images are built on top of Debian 9 (stretch), 10 (buster), and 11 (bullseye):
 
 ```sh
 # 3.2:
@@ -73,18 +73,18 @@ docker pull quay.io/evl.ms/fullstaq-ruby:3.0.6-malloctrim-stretch-slim
 docker pull quay.io/evl.ms/fullstaq-ruby:3.0.6-malloctrim-stretch
 
 # 2.7:
-docker pull quay.io/evl.ms/fullstaq-ruby:2.7.7-jemalloc-bullseye-slim
-docker pull quay.io/evl.ms/fullstaq-ruby:2.7.7-jemalloc-bullseye
-docker pull quay.io/evl.ms/fullstaq-ruby:2.7.7-jemalloc-buster-slim
-docker pull quay.io/evl.ms/fullstaq-ruby:2.7.7-jemalloc-buster
-docker pull quay.io/evl.ms/fullstaq-ruby:2.7.7-jemalloc-stretch-slim
-docker pull quay.io/evl.ms/fullstaq-ruby:2.7.7-jemalloc-stretch
-docker pull quay.io/evl.ms/fullstaq-ruby:2.7.7-malloctrim-bullseye-slim
-docker pull quay.io/evl.ms/fullstaq-ruby:2.7.7-malloctrim-bullseye
-docker pull quay.io/evl.ms/fullstaq-ruby:2.7.7-malloctrim-buster-slim
-docker pull quay.io/evl.ms/fullstaq-ruby:2.7.7-malloctrim-buster
-docker pull quay.io/evl.ms/fullstaq-ruby:2.7.7-malloctrim-stretch-slim
-docker pull quay.io/evl.ms/fullstaq-ruby:2.7.7-malloctrim-stretch
+docker pull quay.io/evl.ms/fullstaq-ruby:2.7.8-jemalloc-bullseye-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:2.7.8-jemalloc-bullseye
+docker pull quay.io/evl.ms/fullstaq-ruby:2.7.8-jemalloc-buster-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:2.7.8-jemalloc-buster
+docker pull quay.io/evl.ms/fullstaq-ruby:2.7.8-jemalloc-stretch-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:2.7.8-jemalloc-stretch
+docker pull quay.io/evl.ms/fullstaq-ruby:2.7.8-malloctrim-bullseye-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:2.7.8-malloctrim-bullseye
+docker pull quay.io/evl.ms/fullstaq-ruby:2.7.8-malloctrim-buster-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:2.7.8-malloctrim-buster
+docker pull quay.io/evl.ms/fullstaq-ruby:2.7.8-malloctrim-stretch-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:2.7.8-malloctrim-stretch
 ```
 
 Latest patch versions for Ruby 3.2 on Debian 11 (bullseye) are also aliased with shortened tags including major and minor versions only: `3.2.2-jemalloc-bullseye → 3.2-jemalloc`

--- a/README.md
+++ b/README.md
@@ -20,29 +20,29 @@ docker pull quay.io/evl.ms/fullstaq-ruby:3.1-jemalloc-slim
 Or use as base image in your `Dockerfile`:
 
 ```docker
-ARG RUBY_VERSION=3.2.1-jemalloc
+ARG RUBY_VERSION=3.2.2-jemalloc
 
 FROM quay.io/evl.ms/fullstaq-ruby:${RUBY_VERSION}-slim
 ```
 
 ## Flavors
 
-Ruby 3.2.1, 3.1.3, 3.0.5, and 2.7.7 with jemalloc and malloctrim are available. Images are built on top of Debian 9 (stretch), 10 (buster), and 11 (bullseye):
+Ruby 3.2.2, 3.1.3, 3.0.5, and 2.7.7 with jemalloc and malloctrim are available. Images are built on top of Debian 9 (stretch), 10 (buster), and 11 (bullseye):
 
 ```sh
 # 3.2:
-docker pull quay.io/evl.ms/fullstaq-ruby:3.2.1-jemalloc-bullseye-slim
-docker pull quay.io/evl.ms/fullstaq-ruby:3.2.1-jemalloc-bullseye
-docker pull quay.io/evl.ms/fullstaq-ruby:3.2.1-jemalloc-buster-slim
-docker pull quay.io/evl.ms/fullstaq-ruby:3.2.1-jemalloc-buster
-docker pull quay.io/evl.ms/fullstaq-ruby:3.2.1-jemalloc-stretch-slim
-docker pull quay.io/evl.ms/fullstaq-ruby:3.2.1-jemalloc-stretch
-docker pull quay.io/evl.ms/fullstaq-ruby:3.2.1-malloctrim-bullseye-slim
-docker pull quay.io/evl.ms/fullstaq-ruby:3.2.1-malloctrim-bullseye
-docker pull quay.io/evl.ms/fullstaq-ruby:3.2.1-malloctrim-buster-slim
-docker pull quay.io/evl.ms/fullstaq-ruby:3.2.1-malloctrim-buster
-docker pull quay.io/evl.ms/fullstaq-ruby:3.2.1-malloctrim-stretch-slim
-docker pull quay.io/evl.ms/fullstaq-ruby:3.2.1-malloctrim-stretch
+docker pull quay.io/evl.ms/fullstaq-ruby:3.2.2-jemalloc-bullseye-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:3.2.2-jemalloc-bullseye
+docker pull quay.io/evl.ms/fullstaq-ruby:3.2.2-jemalloc-buster-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:3.2.2-jemalloc-buster
+docker pull quay.io/evl.ms/fullstaq-ruby:3.2.2-jemalloc-stretch-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:3.2.2-jemalloc-stretch
+docker pull quay.io/evl.ms/fullstaq-ruby:3.2.2-malloctrim-bullseye-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:3.2.2-malloctrim-bullseye
+docker pull quay.io/evl.ms/fullstaq-ruby:3.2.2-malloctrim-buster-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:3.2.2-malloctrim-buster
+docker pull quay.io/evl.ms/fullstaq-ruby:3.2.2-malloctrim-stretch-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:3.2.2-malloctrim-stretch
 
 # 3.1:
 docker pull quay.io/evl.ms/fullstaq-ruby:3.1.3-jemalloc-bullseye-slim
@@ -87,7 +87,7 @@ docker pull quay.io/evl.ms/fullstaq-ruby:2.7.7-malloctrim-stretch-slim
 docker pull quay.io/evl.ms/fullstaq-ruby:2.7.7-malloctrim-stretch
 ```
 
-Latest patch versions for Ruby 3.2 on Debian 11 (bullseye) are also aliased with shortened tags including major and minor versions only: `3.2.1-jemalloc-bullseye → 3.2-jemalloc`
+Latest patch versions for Ruby 3.2 on Debian 11 (bullseye) are also aliased with shortened tags including major and minor versions only: `3.2.2-jemalloc-bullseye → 3.2-jemalloc`
 
 ```sh
 docker pull quay.io/evl.ms/fullstaq-ruby:3.2-jemalloc-slim   # Same as quay.io/evl.ms/fullstaq-ruby:3.2.3-jemalloc-bullseye-slim

--- a/README.md
+++ b/README.md
@@ -90,10 +90,10 @@ docker pull quay.io/evl.ms/fullstaq-ruby:2.7.8-malloctrim-stretch
 Latest patch versions for Ruby 3.2 on Debian 11 (bullseye) are also aliased with shortened tags including major and minor versions only: `3.2.2-jemalloc-bullseye → 3.2-jemalloc`
 
 ```sh
-docker pull quay.io/evl.ms/fullstaq-ruby:3.2-jemalloc-slim   # Same as quay.io/evl.ms/fullstaq-ruby:3.2.3-jemalloc-bullseye-slim
-docker pull quay.io/evl.ms/fullstaq-ruby:3.2-jemalloc        # Same as quay.io/evl.ms/fullstaq-ruby:3.2.3-jemalloc-bullseye
-docker pull quay.io/evl.ms/fullstaq-ruby:3.2-malloctrim-slim # Same as quay.io/evl.ms/fullstaq-ruby:3.2.3-malloctrim-bullseye-slim
-docker pull quay.io/evl.ms/fullstaq-ruby:3.2-malloctrim      # Same as quay.io/evl.ms/fullstaq-ruby:3.2.3-malloctrim-bullseye
+docker pull quay.io/evl.ms/fullstaq-ruby:3.2-jemalloc-slim   # Same as quay.io/evl.ms/fullstaq-ruby:3.2.2-jemalloc-bullseye-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:3.2-jemalloc        # Same as quay.io/evl.ms/fullstaq-ruby:3.2.2-jemalloc-bullseye
+docker pull quay.io/evl.ms/fullstaq-ruby:3.2-malloctrim-slim # Same as quay.io/evl.ms/fullstaq-ruby:3.2.2-malloctrim-bullseye-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:3.2-malloctrim      # Same as quay.io/evl.ms/fullstaq-ruby:3.2.2-malloctrim-bullseye
 ```
 
 For Ruby 3.0 and older, short aliases for latest patch versions are made against Debian 10 (buster): `3.0.6-jemalloc-buster → 3.0-jemalloc`

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ FROM quay.io/evl.ms/fullstaq-ruby:${RUBY_VERSION}-slim
 
 ## Flavors
 
-Ruby 3.2.2, 3.1.3, 3.0.5, and 2.7.7 with jemalloc and malloctrim are available. Images are built on top of Debian 9 (stretch), 10 (buster), and 11 (bullseye):
+Ruby 3.2.2, 3.1.4, 3.0.5, and 2.7.7 with jemalloc and malloctrim are available. Images are built on top of Debian 9 (stretch), 10 (buster), and 11 (bullseye):
 
 ```sh
 # 3.2:
@@ -45,18 +45,18 @@ docker pull quay.io/evl.ms/fullstaq-ruby:3.2.2-malloctrim-stretch-slim
 docker pull quay.io/evl.ms/fullstaq-ruby:3.2.2-malloctrim-stretch
 
 # 3.1:
-docker pull quay.io/evl.ms/fullstaq-ruby:3.1.3-jemalloc-bullseye-slim
-docker pull quay.io/evl.ms/fullstaq-ruby:3.1.3-jemalloc-bullseye
-docker pull quay.io/evl.ms/fullstaq-ruby:3.1.3-jemalloc-buster-slim
-docker pull quay.io/evl.ms/fullstaq-ruby:3.1.3-jemalloc-buster
-docker pull quay.io/evl.ms/fullstaq-ruby:3.1.3-jemalloc-stretch-slim
-docker pull quay.io/evl.ms/fullstaq-ruby:3.1.3-jemalloc-stretch
-docker pull quay.io/evl.ms/fullstaq-ruby:3.1.3-malloctrim-bullseye-slim
-docker pull quay.io/evl.ms/fullstaq-ruby:3.1.3-malloctrim-bullseye
-docker pull quay.io/evl.ms/fullstaq-ruby:3.1.3-malloctrim-buster-slim
-docker pull quay.io/evl.ms/fullstaq-ruby:3.1.3-malloctrim-buster
-docker pull quay.io/evl.ms/fullstaq-ruby:3.1.3-malloctrim-stretch-slim
-docker pull quay.io/evl.ms/fullstaq-ruby:3.1.3-malloctrim-stretch
+docker pull quay.io/evl.ms/fullstaq-ruby:3.1.4-jemalloc-bullseye-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:3.1.4-jemalloc-bullseye
+docker pull quay.io/evl.ms/fullstaq-ruby:3.1.4-jemalloc-buster-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:3.1.4-jemalloc-buster
+docker pull quay.io/evl.ms/fullstaq-ruby:3.1.4-jemalloc-stretch-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:3.1.4-jemalloc-stretch
+docker pull quay.io/evl.ms/fullstaq-ruby:3.1.4-malloctrim-bullseye-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:3.1.4-malloctrim-bullseye
+docker pull quay.io/evl.ms/fullstaq-ruby:3.1.4-malloctrim-buster-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:3.1.4-malloctrim-buster
+docker pull quay.io/evl.ms/fullstaq-ruby:3.1.4-malloctrim-stretch-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:3.1.4-malloctrim-stretch
 
 # 3.0:
 docker pull quay.io/evl.ms/fullstaq-ruby:3.0.5-jemalloc-bullseye-slim


### PR DESCRIPTION
Adds the new ruby version with fixes for the CVE's:
* [CVE-2023-28755: ReDoS vulnerability in URI](https://www.ruby-lang.org/en/news/2023/03/28/redos-in-uri-cve-2023-28755/)
* [CVE-2023-28756: ReDoS vulnerability in Time](https://www.ruby-lang.org/en/news/2023/03/30/redos-in-time-cve-2023-28756/)

Changelogs:
* [ruby-lang.org/en/news/2023/03/30/ruby-3-2-2-released](https://www.ruby-lang.org/en/news/2023/03/30/ruby-3-2-2-released/)
* [ruby-lang.org/en/news/2023/03/30/ruby-3-1-4-released](https://www.ruby-lang.org/en/news/2023/03/30/ruby-3-1-4-released/)
* [ruby-lang.org/en/news/2023/03/30/ruby-3-0-6-released](https://www.ruby-lang.org/en/news/2023/03/30/ruby-3-0-6-released/)
* [ruby-lang.org/en/news/2023/03/30/ruby-2-7-8-released](https://www.ruby-lang.org/en/news/2023/03/30/ruby-2-7-8-released/)
