### PR TITLE
Fix ruby not found after load /etc/profile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,7 @@ ENV BUNDLE_PATH="$GEM_HOME" \
     LANG=C.UTF-8 LC_ALL=C.UTF-8
 
 # path recommendation: https://github.com/bundler/bundler/pull/6469#issuecomment-383235438
+RUN echo "PATH=$GEM_HOME/bin:$BUNDLE_PATH/gems/bin:/usr/lib/fullstaq-ruby/versions/${RUBY_VERSION}/bin:$PATH" >> /etc/profile.d/fullstaq-ruby.sh
 ENV PATH $GEM_HOME/bin:$BUNDLE_PATH/gems/bin:/usr/lib/fullstaq-ruby/versions/${RUBY_VERSION}/bin:$PATH
 
 CMD [ "irb" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,8 @@ ENV BUNDLE_PATH="$GEM_HOME" \
     LANG=C.UTF-8 LC_ALL=C.UTF-8
 
 # path recommendation: https://github.com/bundler/bundler/pull/6469#issuecomment-383235438
-RUN echo "PATH=$GEM_HOME/bin:$BUNDLE_PATH/gems/bin:/usr/lib/fullstaq-ruby/versions/${RUBY_VERSION}/bin:$PATH" >> /etc/profile.d/fullstaq-ruby.sh
 ENV PATH $GEM_HOME/bin:$BUNDLE_PATH/gems/bin:/usr/lib/fullstaq-ruby/versions/${RUBY_VERSION}/bin:$PATH
+# Make login shell (bash -l) to have the same path as regular one.
+RUN echo 'PATH=$GEM_HOME/bin:$BUNDLE_PATH/gems/bin:/usr/lib/fullstaq-ruby/versions/${RUBY_VERSION}/bin:$PATH' >> /etc/profile.d/fullstaq-ruby.sh
 
 CMD [ "irb" ]

--- a/README.md
+++ b/README.md
@@ -87,16 +87,6 @@ For Ruby 3.0 and older, short aliases for latest patch versions are made against
 
 Ruby is installed from official APT package repository. Rbenv isn't used.
 
-## Caveats
-
-Bash login shell `bash -l -c 'command'` resets `$PATH` to default. It is not clear why it happens there, because in official Ruby image it works and this image is based on the same `debian:stretch-slim` base image.
-
-That may hurt you if you're using `whenever` gem which wraps every command in Bash login shell by default. To remove this wrapping place following to the top of your `config/schedule.rb`:
-
-```ruby
-# config/schedule.rb
-set :job_template, nil
-```
 
 [Fullstaq Ruby]: https://fullstaqruby.org/ "Ruby, optimized for production"
 [Hongli Lai]: https://www.joyfulbikeshedding.com/


### PR DESCRIPTION
### Motivation / Background

I used [whenever](https://github.com/javan/whenever) in code. The task prefix in the crontab file generated by whenever is `bash -l -c {XXX}`, which loads the `/etc/profile` file and changes PATH, resulting in a "command not found" error.

### Changed

Writing the PATH setting into `/etc/profile` is to avoid the problem of command not found due to PATH changes.

_PS: English is not my native language; please excuse typing errors._

