### PR TITLE
Adds Ruby 3.3.0

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -23,24 +23,32 @@ jobs:
             debian-image:   "bookworm"
             debian-version: "12"
             aliases: |
+              quay.io/evl.ms/fullstaq-ruby:3.3-jemalloc
+              quay.io/evl.ms/fullstaq-ruby:3.3.0-jemalloc
               quay.io/evl.ms/fullstaq-ruby:3.3-jemalloc-bookworm
           - ruby-version:   "3.3.0"
             ruby-variant:   "jemalloc"
             debian-image:   "bookworm-slim"
             debian-version: "12"
             aliases: |
+              quay.io/evl.ms/fullstaq-ruby:3.3-jemalloc-slim
+              quay.io/evl.ms/fullstaq-ruby:3.3.0-jemalloc-slim
               quay.io/evl.ms/fullstaq-ruby:3.3-jemalloc-bookworm-slim
           - ruby-version:   "3.3.0"
             ruby-variant:   "malloctrim"
             debian-image:   "bookworm"
             debian-version: "12"
             aliases: |
+              quay.io/evl.ms/fullstaq-ruby:3.3-malloctrim
+              quay.io/evl.ms/fullstaq-ruby:3.3.0-malloctrim
               quay.io/evl.ms/fullstaq-ruby:3.3-malloctrim-bookworm
           - ruby-version:   "3.3.0"
             ruby-variant:   "malloctrim"
             debian-image:   "bookworm-slim"
             debian-version: "12"
             aliases: |
+              quay.io/evl.ms/fullstaq-ruby:3.3-malloctrim-slim
+              quay.io/evl.ms/fullstaq-ruby:3.3.0-malloctrim-slim
               quay.io/evl.ms/fullstaq-ruby:3.3-malloctrim-bookworm-slim
 
           # 3.3.0 on Debian 11
@@ -48,30 +56,26 @@ jobs:
             ruby-variant:   "jemalloc"
             debian-image:   "bullseye"
             debian-version: "11"
-            aliases:  |
-              quay.io/evl.ms/fullstaq-ruby:3.3.0-jemalloc
-              quay.io/evl.ms/fullstaq-ruby:3.3-jemalloc
+            aliases: |
+              quay.io/evl.ms/fullstaq-ruby:3.3-jemalloc-bullseye
           - ruby-version:   "3.3.0"
             ruby-variant:   "jemalloc"
             debian-image:   "bullseye-slim"
             debian-version: "11"
             aliases: |
-              quay.io/evl.ms/fullstaq-ruby:3.3.0-jemalloc-slim
-              quay.io/evl.ms/fullstaq-ruby:3.3-jemalloc-slim
+              quay.io/evl.ms/fullstaq-ruby:3.3-jemalloc-bullseye-slim
           - ruby-version:   "3.3.0"
             ruby-variant:   "malloctrim"
             debian-image:   "bullseye"
             debian-version: "11"
-            aliases:  |
-              quay.io/evl.ms/fullstaq-ruby:3.3.0-malloctrim
-              quay.io/evl.ms/fullstaq-ruby:3.3-malloctrim
+            aliases: |
+              quay.io/evl.ms/fullstaq-ruby:3.3-malloctrim-bullseye
           - ruby-version:   "3.3.0"
             ruby-variant:   "malloctrim"
             debian-image:   "bullseye-slim"
             debian-version: "11"
             aliases: |
-              quay.io/evl.ms/fullstaq-ruby:3.3.0-malloctrim-slim
-              quay.io/evl.ms/fullstaq-ruby:3.3-malloctrim-slim
+              quay.io/evl.ms/fullstaq-ruby:3.3-malloctrim-bullseye-slim
 
           # 3.3.0 on Debian 10
           - ruby-version:   "3.3.0"

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -17,6 +17,80 @@ jobs:
       matrix:
         include:
 
+          # 3.3.0 on Debian 12
+          - ruby-version:   "3.3.0"
+            ruby-variant:   "jemalloc"
+            debian-image:   "bookworm"
+            debian-version: "12"
+            aliases: |
+              quay.io/evl.ms/fullstaq-ruby:3.3-jemalloc-bookworm
+          - ruby-version:   "3.3.0"
+            ruby-variant:   "jemalloc"
+            debian-image:   "bookworm-slim"
+            debian-version: "12"
+            aliases: |
+              quay.io/evl.ms/fullstaq-ruby:3.3-jemalloc-bookworm-slim
+          - ruby-version:   "3.3.0"
+            ruby-variant:   "malloctrim"
+            debian-image:   "bookworm"
+            debian-version: "12"
+            aliases: |
+              quay.io/evl.ms/fullstaq-ruby:3.3-malloctrim-bookworm
+          - ruby-version:   "3.3.0"
+            ruby-variant:   "malloctrim"
+            debian-image:   "bookworm-slim"
+            debian-version: "12"
+            aliases: |
+              quay.io/evl.ms/fullstaq-ruby:3.3-malloctrim-bookworm-slim
+
+          # 3.3.0 on Debian 11
+          - ruby-version:   "3.3.0"
+            ruby-variant:   "jemalloc"
+            debian-image:   "bullseye"
+            debian-version: "11"
+            aliases:  |
+              quay.io/evl.ms/fullstaq-ruby:3.3.0-jemalloc
+              quay.io/evl.ms/fullstaq-ruby:3.3-jemalloc
+          - ruby-version:   "3.3.0"
+            ruby-variant:   "jemalloc"
+            debian-image:   "bullseye-slim"
+            debian-version: "11"
+            aliases: |
+              quay.io/evl.ms/fullstaq-ruby:3.3.0-jemalloc-slim
+              quay.io/evl.ms/fullstaq-ruby:3.3-jemalloc-slim
+          - ruby-version:   "3.3.0"
+            ruby-variant:   "malloctrim"
+            debian-image:   "bullseye"
+            debian-version: "11"
+            aliases:  |
+              quay.io/evl.ms/fullstaq-ruby:3.3.0-malloctrim
+              quay.io/evl.ms/fullstaq-ruby:3.3-malloctrim
+          - ruby-version:   "3.3.0"
+            ruby-variant:   "malloctrim"
+            debian-image:   "bullseye-slim"
+            debian-version: "11"
+            aliases: |
+              quay.io/evl.ms/fullstaq-ruby:3.3.0-malloctrim-slim
+              quay.io/evl.ms/fullstaq-ruby:3.3-malloctrim-slim
+
+          # 3.3.0 on Debian 10
+          - ruby-version:   "3.3.0"
+            ruby-variant:   "jemalloc"
+            debian-image:   "buster"
+            debian-version: "10"
+          - ruby-version:   "3.3.0"
+            ruby-variant:   "jemalloc"
+            debian-image:   "buster-slim"
+            debian-version: "10"
+          - ruby-version:   "3.3.0"
+            ruby-variant:   "malloctrim"
+            debian-image:   "buster"
+            debian-version: "10"
+          - ruby-version:   "3.3.0"
+            ruby-variant:   "malloctrim"
+            debian-image:   "buster-slim"
+            debian-version: "10"
+
           # 3.2.2 on Debian 12
           - ruby-version:   "3.2.2"
             ruby-variant:   "jemalloc"

--- a/README.md
+++ b/README.md
@@ -10,26 +10,39 @@ These images are intended to be used while [Fullstaq] and [Hongli Lai] haven't b
 </a>
 
 ## Usage
-
 Pull it directly from the quay.io registry:
 
 ```sh
-docker pull quay.io/evl.ms/fullstaq-ruby:3.1-jemalloc-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:3.3-jemalloc-slim
 ```
 
 Or use as base image in your `Dockerfile`:
 
 ```docker
-ARG RUBY_VERSION=3.2.2-jemalloc
+ARG RUBY_VERSION=3.3.0-jemalloc
 
 FROM quay.io/evl.ms/fullstaq-ruby:${RUBY_VERSION}-slim
 ```
 
 ## Flavors
 
-Ruby 3.2.2, 3.1.4, 3.0.6, and 2.7.8 with jemalloc and malloctrim are available. Images are built on top of Debian 10 (buster), 11 (bullseye), also Ruby 3.2 and newer are build on top of Debian 12 (bookworm):
+Ruby 3.3.0, 3.2.2, 3.1.4, 3.0.6, and 2.7.8 with jemalloc and malloctrim are available. Images are built on top of Debian 10 (buster), 11 (bullseye), also Ruby 3.2 and newer are build on top of Debian 12 (bookworm):
 
 ```sh
+# 3.3:
+docker pull quay.io/evl.ms/fullstaq-ruby:3.3.0-jemalloc-bookworm-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:3.3.0-jemalloc-bookworm
+docker pull quay.io/evl.ms/fullstaq-ruby:3.3.0-jemalloc-bullseye-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:3.3.0-jemalloc-bullseye
+docker pull quay.io/evl.ms/fullstaq-ruby:3.3.0-jemalloc-buster-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:3.3.0-jemalloc-buster
+docker pull quay.io/evl.ms/fullstaq-ruby:3.3.0-malloctrim-bookworm-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:3.3.0-malloctrim-bookworm
+docker pull quay.io/evl.ms/fullstaq-ruby:3.3.0-malloctrim-bullseye-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:3.3.0-malloctrim-bullseye
+docker pull quay.io/evl.ms/fullstaq-ruby:3.3.0-malloctrim-buster-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:3.3.0-malloctrim-buster
+
 # 3.2:
 docker pull quay.io/evl.ms/fullstaq-ruby:3.2.2-jemalloc-bookworm-slim
 docker pull quay.io/evl.ms/fullstaq-ruby:3.2.2-jemalloc-bookworm
@@ -75,13 +88,13 @@ docker pull quay.io/evl.ms/fullstaq-ruby:2.7.8-malloctrim-buster-slim
 docker pull quay.io/evl.ms/fullstaq-ruby:2.7.8-malloctrim-buster
 ```
 
-Latest patch versions for Ruby 3.2 on Debian 11 (bullseye) are also aliased with shortened tags including major and minor versions only: `3.2.2-jemalloc-bullseye → 3.2-jemalloc`
+Latest patch versions for Ruby 3.3 on Debian 11 (bullseye) are also aliased with shortened tags including major and minor versions only: `3.3.0-jemalloc-bullseye → 3.3-jemalloc`
 
 ```sh
-docker pull quay.io/evl.ms/fullstaq-ruby:3.2-jemalloc-slim   # Same as quay.io/evl.ms/fullstaq-ruby:3.2.2-jemalloc-bullseye-slim
-docker pull quay.io/evl.ms/fullstaq-ruby:3.2-jemalloc        # Same as quay.io/evl.ms/fullstaq-ruby:3.2.2-jemalloc-bullseye
-docker pull quay.io/evl.ms/fullstaq-ruby:3.2-malloctrim-slim # Same as quay.io/evl.ms/fullstaq-ruby:3.2.2-malloctrim-bullseye-slim
-docker pull quay.io/evl.ms/fullstaq-ruby:3.2-malloctrim      # Same as quay.io/evl.ms/fullstaq-ruby:3.2.2-malloctrim-bullseye
+docker pull quay.io/evl.ms/fullstaq-ruby:3.3-jemalloc-slim   # Same as quay.io/evl.ms/fullstaq-ruby:3.3.0-jemalloc-bullseye-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:3.3-jemalloc        # Same as quay.io/evl.ms/fullstaq-ruby:3.3.0-jemalloc-bullseye
+docker pull quay.io/evl.ms/fullstaq-ruby:3.3-malloctrim-slim # Same as quay.io/evl.ms/fullstaq-ruby:3.3.0-malloctrim-bullseye-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:3.3-malloctrim      # Same as quay.io/evl.ms/fullstaq-ruby:3.3.0-malloctrim-bullseye
 ```
 
 For Ruby 3.0 and older, short aliases for latest patch versions are made against Debian 10 (buster): `3.0.6-jemalloc-buster → 3.0-jemalloc`

--- a/README.md
+++ b/README.md
@@ -88,16 +88,18 @@ docker pull quay.io/evl.ms/fullstaq-ruby:2.7.8-malloctrim-buster-slim
 docker pull quay.io/evl.ms/fullstaq-ruby:2.7.8-malloctrim-buster
 ```
 
-Latest patch versions for Ruby 3.3 on Debian 11 (bullseye) are also aliased with shortened tags including major and minor versions only: `3.3.0-jemalloc-bullseye → 3.3-jemalloc`
+Latest patch versions for Ruby 3.3 on Debian 12 (bookworm) are also aliased with shortened tags including major and minor versions only: `3.3.0-jemalloc-bookworm → 3.3-jemalloc`
 
 ```sh
-docker pull quay.io/evl.ms/fullstaq-ruby:3.3-jemalloc-slim   # Same as quay.io/evl.ms/fullstaq-ruby:3.3.0-jemalloc-bullseye-slim
-docker pull quay.io/evl.ms/fullstaq-ruby:3.3-jemalloc        # Same as quay.io/evl.ms/fullstaq-ruby:3.3.0-jemalloc-bullseye
-docker pull quay.io/evl.ms/fullstaq-ruby:3.3-malloctrim-slim # Same as quay.io/evl.ms/fullstaq-ruby:3.3.0-malloctrim-bullseye-slim
-docker pull quay.io/evl.ms/fullstaq-ruby:3.3-malloctrim      # Same as quay.io/evl.ms/fullstaq-ruby:3.3.0-malloctrim-bullseye
+docker pull quay.io/evl.ms/fullstaq-ruby:3.3-jemalloc-slim   # Same as quay.io/evl.ms/fullstaq-ruby:3.3.0-jemalloc-bookworm-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:3.3-jemalloc        # Same as quay.io/evl.ms/fullstaq-ruby:3.3.0-jemalloc-bookworm
+docker pull quay.io/evl.ms/fullstaq-ruby:3.3-malloctrim-slim # Same as quay.io/evl.ms/fullstaq-ruby:3.3.0-malloctrim-bookworm-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:3.3-malloctrim      # Same as quay.io/evl.ms/fullstaq-ruby:3.3.0-malloctrim-bookworm
 ```
 
-For Ruby 3.0 and older, short aliases for latest patch versions are made against Debian 10 (buster): `3.0.6-jemalloc-buster → 3.0-jemalloc`
+For Ruby 3.2 and 3.1, short aliases for latest patch versions are made against Debian 11 (bullseye): `3.2.2-jemalloc-bullseye → 3.2-jemalloc`
+
+For Ruby 3.0 and 2.7, short aliases for latest patch versions are made against Debian 10 (buster): `3.0.6-jemalloc-buster → 3.0-jemalloc`
 
 
 ## Details


### PR DESCRIPTION
This PR adds the Ruby 3.3.0 in all the variants possible and fixes #26 

Changelog:

https://www.ruby-lang.org/en/news/2023/12/25/ruby-3-3-0-released/
