### PR TITLE
Remove Ruby 2.7 since it’s EOL

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -265,54 +265,6 @@ jobs:
               quay.io/evl.ms/fullstaq-ruby:3.0.6-malloctrim-slim
               quay.io/evl.ms/fullstaq-ruby:3.0-malloctrim-slim
 
-          # 2.7.8 on Debian 11
-          - ruby-version:   "2.7.8"
-            ruby-variant:   "jemalloc"
-            debian-image:   "bullseye"
-            debian-version: "11"
-          - ruby-version:   "2.7.8"
-            ruby-variant:   "jemalloc"
-            debian-image:   "bullseye-slim"
-            debian-version: "11"
-          - ruby-version:   "2.7.8"
-            ruby-variant:   "malloctrim"
-            debian-image:   "bullseye"
-            debian-version: "11"
-          - ruby-version:   "2.7.8"
-            ruby-variant:   "malloctrim"
-            debian-image:   "bullseye-slim"
-            debian-version: "11"
-
-          # 2.7.8 on Debian 10
-          - ruby-version:   "2.7.8"
-            ruby-variant:   "jemalloc"
-            debian-image:   "buster"
-            debian-version: "10"
-            aliases:  |
-              quay.io/evl.ms/fullstaq-ruby:2.7.8-jemalloc
-              quay.io/evl.ms/fullstaq-ruby:2.7-jemalloc
-          - ruby-version:   "2.7.8"
-            ruby-variant:   "jemalloc"
-            debian-image:   "buster-slim"
-            debian-version: "10"
-            aliases: |
-              quay.io/evl.ms/fullstaq-ruby:2.7.8-jemalloc-slim
-              quay.io/evl.ms/fullstaq-ruby:2.7-jemalloc-slim
-          - ruby-version:   "2.7.8"
-            ruby-variant:   "malloctrim"
-            debian-image:   "buster"
-            debian-version: "10"
-            aliases:  |
-              quay.io/evl.ms/fullstaq-ruby:2.7.8-malloctrim
-              quay.io/evl.ms/fullstaq-ruby:2.7-malloctrim
-          - ruby-version:   "2.7.8"
-            ruby-variant:   "malloctrim"
-            debian-image:   "buster-slim"
-            debian-version: "10"
-            aliases: |
-              quay.io/evl.ms/fullstaq-ruby:2.7.8-malloctrim-slim
-              quay.io/evl.ms/fullstaq-ruby:2.7-malloctrim-slim
-
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ FROM quay.io/evl.ms/fullstaq-ruby:${RUBY_VERSION}-slim
 
 ## Flavors
 
-Ruby 3.3.0, 3.2.2, 3.1.4, 3.0.6, and 2.7.8 with jemalloc and malloctrim are available. Images are built on top of Debian 10 (buster), 11 (bullseye), also Ruby 3.2 and newer are build on top of Debian 12 (bookworm):
+Ruby 3.3.0, 3.2.2, 3.1.4, and 3.0.6 with jemalloc and malloctrim are available. Images are built on top of Debian 10 (buster), 11 (bullseye), also Ruby 3.2 and newer are build on top of Debian 12 (bookworm):
 
 ```sh
 # 3.3:
@@ -76,16 +76,6 @@ docker pull quay.io/evl.ms/fullstaq-ruby:3.0.6-malloctrim-bullseye-slim
 docker pull quay.io/evl.ms/fullstaq-ruby:3.0.6-malloctrim-bullseye
 docker pull quay.io/evl.ms/fullstaq-ruby:3.0.6-malloctrim-buster-slim
 docker pull quay.io/evl.ms/fullstaq-ruby:3.0.6-malloctrim-buster
-
-# 2.7:
-docker pull quay.io/evl.ms/fullstaq-ruby:2.7.8-jemalloc-bullseye-slim
-docker pull quay.io/evl.ms/fullstaq-ruby:2.7.8-jemalloc-bullseye
-docker pull quay.io/evl.ms/fullstaq-ruby:2.7.8-jemalloc-buster-slim
-docker pull quay.io/evl.ms/fullstaq-ruby:2.7.8-jemalloc-buster
-docker pull quay.io/evl.ms/fullstaq-ruby:2.7.8-malloctrim-bullseye-slim
-docker pull quay.io/evl.ms/fullstaq-ruby:2.7.8-malloctrim-bullseye
-docker pull quay.io/evl.ms/fullstaq-ruby:2.7.8-malloctrim-buster-slim
-docker pull quay.io/evl.ms/fullstaq-ruby:2.7.8-malloctrim-buster
 ```
 
 Latest patch versions for Ruby 3.3 on Debian 12 (bookworm) are also aliased with shortened tags including major and minor versions only: `3.3.0-jemalloc-bookworm → 3.3-jemalloc`
@@ -99,7 +89,7 @@ docker pull quay.io/evl.ms/fullstaq-ruby:3.3-malloctrim      # Same as quay.io/e
 
 For Ruby 3.2 and 3.1, short aliases for latest patch versions are made against Debian 11 (bullseye): `3.2.2-jemalloc-bullseye → 3.2-jemalloc`
 
-For Ruby 3.0 and 2.7, short aliases for latest patch versions are made against Debian 10 (buster): `3.0.6-jemalloc-buster → 3.0-jemalloc`
+For Ruby 3.0, short aliases for latest patch versions are made against Debian 10 (buster): `3.0.6-jemalloc-buster → 3.0-jemalloc`
 
 
 ## Details


### PR DESCRIPTION
Since this version is end of life since 31 March, it doesn’t really make since to still include it I think.