### PR TITLE
Upgrade Ruby to 3.1.6 and 3.3.2

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -17,80 +17,80 @@ jobs:
       matrix:
         include:
 
-          # 3.3.1 on Debian 12
-          - ruby-version:   "3.3.1"
+          # 3.3.2 on Debian 12
+          - ruby-version:   "3.3.2"
             ruby-variant:   "jemalloc"
             debian-image:   "bookworm"
             debian-version: "12"
             aliases: |
               quay.io/evl.ms/fullstaq-ruby:3.3-jemalloc
-              quay.io/evl.ms/fullstaq-ruby:3.3.1-jemalloc
+              quay.io/evl.ms/fullstaq-ruby:3.3.2-jemalloc
               quay.io/evl.ms/fullstaq-ruby:3.3-jemalloc-bookworm
-          - ruby-version:   "3.3.1"
+          - ruby-version:   "3.3.2"
             ruby-variant:   "jemalloc"
             debian-image:   "bookworm-slim"
             debian-version: "12"
             aliases: |
               quay.io/evl.ms/fullstaq-ruby:3.3-jemalloc-slim
-              quay.io/evl.ms/fullstaq-ruby:3.3.1-jemalloc-slim
+              quay.io/evl.ms/fullstaq-ruby:3.3.2-jemalloc-slim
               quay.io/evl.ms/fullstaq-ruby:3.3-jemalloc-bookworm-slim
-          - ruby-version:   "3.3.1"
+          - ruby-version:   "3.3.2"
             ruby-variant:   "malloctrim"
             debian-image:   "bookworm"
             debian-version: "12"
             aliases: |
               quay.io/evl.ms/fullstaq-ruby:3.3-malloctrim
-              quay.io/evl.ms/fullstaq-ruby:3.3.1-malloctrim
+              quay.io/evl.ms/fullstaq-ruby:3.3.2-malloctrim
               quay.io/evl.ms/fullstaq-ruby:3.3-malloctrim-bookworm
-          - ruby-version:   "3.3.1"
+          - ruby-version:   "3.3.2"
             ruby-variant:   "malloctrim"
             debian-image:   "bookworm-slim"
             debian-version: "12"
             aliases: |
               quay.io/evl.ms/fullstaq-ruby:3.3-malloctrim-slim
-              quay.io/evl.ms/fullstaq-ruby:3.3.1-malloctrim-slim
+              quay.io/evl.ms/fullstaq-ruby:3.3.2-malloctrim-slim
               quay.io/evl.ms/fullstaq-ruby:3.3-malloctrim-bookworm-slim
 
-          # 3.3.1 on Debian 11
-          - ruby-version:   "3.3.1"
+          # 3.3.2 on Debian 11
+          - ruby-version:   "3.3.2"
             ruby-variant:   "jemalloc"
             debian-image:   "bullseye"
             debian-version: "11"
             aliases: |
               quay.io/evl.ms/fullstaq-ruby:3.3-jemalloc-bullseye
-          - ruby-version:   "3.3.1"
+          - ruby-version:   "3.3.2"
             ruby-variant:   "jemalloc"
             debian-image:   "bullseye-slim"
             debian-version: "11"
             aliases: |
               quay.io/evl.ms/fullstaq-ruby:3.3-jemalloc-bullseye-slim
-          - ruby-version:   "3.3.1"
+          - ruby-version:   "3.3.2"
             ruby-variant:   "malloctrim"
             debian-image:   "bullseye"
             debian-version: "11"
             aliases: |
               quay.io/evl.ms/fullstaq-ruby:3.3-malloctrim-bullseye
-          - ruby-version:   "3.3.1"
+          - ruby-version:   "3.3.2"
             ruby-variant:   "malloctrim"
             debian-image:   "bullseye-slim"
             debian-version: "11"
             aliases: |
               quay.io/evl.ms/fullstaq-ruby:3.3-malloctrim-bullseye-slim
 
-          # 3.3.1 on Debian 10
-          - ruby-version:   "3.3.1"
+          # 3.3.2 on Debian 10
+          - ruby-version:   "3.3.2"
             ruby-variant:   "jemalloc"
             debian-image:   "buster"
             debian-version: "10"
-          - ruby-version:   "3.3.1"
+          - ruby-version:   "3.3.2"
             ruby-variant:   "jemalloc"
             debian-image:   "buster-slim"
             debian-version: "10"
-          - ruby-version:   "3.3.1"
+          - ruby-version:   "3.3.2"
             ruby-variant:   "malloctrim"
             debian-image:   "buster"
             debian-version: "10"
-          - ruby-version:   "3.3.1"
+          - ruby-version:   "3.3.2"
             ruby-variant:   "malloctrim"
             debian-image:   "buster-slim"
             debian-version: "10"

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -169,50 +169,50 @@ jobs:
             debian-image:   "buster-slim"
             debian-version: "10"
 
-          # 3.1.5 on Debian 11
-          - ruby-version:   "3.1.5"
+          # 3.1.6 on Debian 11
+          - ruby-version:   "3.1.6"
             ruby-variant:   "jemalloc"
             debian-image:   "bullseye"
             debian-version: "11"
             aliases:  |
-              quay.io/evl.ms/fullstaq-ruby:3.1.5-jemalloc
+              quay.io/evl.ms/fullstaq-ruby:3.1.6-jemalloc
               quay.io/evl.ms/fullstaq-ruby:3.1-jemalloc
-          - ruby-version:   "3.1.5"
+          - ruby-version:   "3.1.6"
             ruby-variant:   "jemalloc"
             debian-image:   "bullseye-slim"
             debian-version: "11"
             aliases: |
-              quay.io/evl.ms/fullstaq-ruby:3.1.5-jemalloc-slim
+              quay.io/evl.ms/fullstaq-ruby:3.1.6-jemalloc-slim
               quay.io/evl.ms/fullstaq-ruby:3.1-jemalloc-slim
-          - ruby-version:   "3.1.5"
+          - ruby-version:   "3.1.6"
             ruby-variant:   "malloctrim"
             debian-image:   "bullseye"
             debian-version: "11"
             aliases:  |
-              quay.io/evl.ms/fullstaq-ruby:3.1.5-malloctrim
+              quay.io/evl.ms/fullstaq-ruby:3.1.6-malloctrim
               quay.io/evl.ms/fullstaq-ruby:3.1-malloctrim
-          - ruby-version:   "3.1.5"
+          - ruby-version:   "3.1.6"
             ruby-variant:   "malloctrim"
             debian-image:   "bullseye-slim"
             debian-version: "11"
             aliases: |
-              quay.io/evl.ms/fullstaq-ruby:3.1.5-malloctrim-slim
+              quay.io/evl.ms/fullstaq-ruby:3.1.6-malloctrim-slim
               quay.io/evl.ms/fullstaq-ruby:3.1-malloctrim-slim
 
-          # 3.1.5 on Debian 10
-          - ruby-version:   "3.1.5"
+          # 3.1.6 on Debian 10
+          - ruby-version:   "3.1.6"
             ruby-variant:   "jemalloc"
             debian-image:   "buster"
             debian-version: "10"
-          - ruby-version:   "3.1.5"
+          - ruby-version:   "3.1.6"
             ruby-variant:   "jemalloc"
             debian-image:   "buster-slim"
             debian-version: "10"
-          - ruby-version:   "3.1.5"
+          - ruby-version:   "3.1.6"
             ruby-variant:   "malloctrim"
             debian-image:   "buster"
             debian-version: "10"
-          - ruby-version:   "3.1.5"
+          - ruby-version:   "3.1.6"
             ruby-variant:   "malloctrim"
             debian-image:   "buster-slim"
             debian-version: "10"

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ FROM quay.io/evl.ms/fullstaq-ruby:${RUBY_VERSION}-slim
 
 ## Flavors
 
-Ruby 3.3.1, 3.2.4, 3.1.5, and 3.0.7 with jemalloc and malloctrim are available. Images are built on top of Debian 10 (buster), 11 (bullseye), also Ruby 3.2 and newer are build on top of Debian 12 (bookworm):
+Ruby 3.3.1, 3.2.4, 3.1.6, and 3.0.7 with jemalloc and malloctrim are available. Images are built on top of Debian 10 (buster), 11 (bullseye), also Ruby 3.2 and newer are build on top of Debian 12 (bookworm):
 
 ```sh
 # 3.3:
@@ -58,14 +58,14 @@ docker pull quay.io/evl.ms/fullstaq-ruby:3.2.4-malloctrim-buster-slim
 docker pull quay.io/evl.ms/fullstaq-ruby:3.2.4-malloctrim-buster
 
 # 3.1:
-docker pull quay.io/evl.ms/fullstaq-ruby:3.1.5-jemalloc-bullseye-slim
-docker pull quay.io/evl.ms/fullstaq-ruby:3.1.5-jemalloc-bullseye
-docker pull quay.io/evl.ms/fullstaq-ruby:3.1.5-jemalloc-buster-slim
-docker pull quay.io/evl.ms/fullstaq-ruby:3.1.5-jemalloc-buster
-docker pull quay.io/evl.ms/fullstaq-ruby:3.1.5-malloctrim-bullseye-slim
-docker pull quay.io/evl.ms/fullstaq-ruby:3.1.5-malloctrim-bullseye
-docker pull quay.io/evl.ms/fullstaq-ruby:3.1.5-malloctrim-buster-slim
-docker pull quay.io/evl.ms/fullstaq-ruby:3.1.5-malloctrim-buster
+docker pull quay.io/evl.ms/fullstaq-ruby:3.1.6-jemalloc-bullseye-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:3.1.6-jemalloc-bullseye
+docker pull quay.io/evl.ms/fullstaq-ruby:3.1.6-jemalloc-buster-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:3.1.6-jemalloc-buster
+docker pull quay.io/evl.ms/fullstaq-ruby:3.1.6-malloctrim-bullseye-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:3.1.6-malloctrim-bullseye
+docker pull quay.io/evl.ms/fullstaq-ruby:3.1.6-malloctrim-buster-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:3.1.6-malloctrim-buster
 
 # 3.0:
 docker pull quay.io/evl.ms/fullstaq-ruby:3.0.7-jemalloc-bullseye-slim

--- a/README.md
+++ b/README.md
@@ -19,29 +19,29 @@ docker pull quay.io/evl.ms/fullstaq-ruby:3.3-jemalloc-slim
 Or use as base image in your `Dockerfile`:
 
 ```docker
-ARG RUBY_VERSION=3.3.1-jemalloc
+ARG RUBY_VERSION=3.3.2-jemalloc
 
 FROM quay.io/evl.ms/fullstaq-ruby:${RUBY_VERSION}-slim
 ```
 
 ## Flavors
 
-Ruby 3.3.1, 3.2.4, 3.1.6, and 3.0.7 with jemalloc and malloctrim are available. Images are built on top of Debian 10 (buster), 11 (bullseye), also Ruby 3.2 and newer are build on top of Debian 12 (bookworm):
+Ruby 3.3.2, 3.2.4, 3.1.6, and 3.0.7 with jemalloc and malloctrim are available. Images are built on top of Debian 10 (buster), 11 (bullseye), also Ruby 3.2 and newer are build on top of Debian 12 (bookworm):
 
 ```sh
 # 3.3:
-docker pull quay.io/evl.ms/fullstaq-ruby:3.3.1-jemalloc-bookworm-slim
-docker pull quay.io/evl.ms/fullstaq-ruby:3.3.1-jemalloc-bookworm
-docker pull quay.io/evl.ms/fullstaq-ruby:3.3.1-jemalloc-bullseye-slim
-docker pull quay.io/evl.ms/fullstaq-ruby:3.3.1-jemalloc-bullseye
-docker pull quay.io/evl.ms/fullstaq-ruby:3.3.1-jemalloc-buster-slim
-docker pull quay.io/evl.ms/fullstaq-ruby:3.3.1-jemalloc-buster
-docker pull quay.io/evl.ms/fullstaq-ruby:3.3.1-malloctrim-bookworm-slim
-docker pull quay.io/evl.ms/fullstaq-ruby:3.3.1-malloctrim-bookworm
-docker pull quay.io/evl.ms/fullstaq-ruby:3.3.1-malloctrim-bullseye-slim
-docker pull quay.io/evl.ms/fullstaq-ruby:3.3.1-malloctrim-bullseye
-docker pull quay.io/evl.ms/fullstaq-ruby:3.3.1-malloctrim-buster-slim
-docker pull quay.io/evl.ms/fullstaq-ruby:3.3.1-malloctrim-buster
+docker pull quay.io/evl.ms/fullstaq-ruby:3.3.2-jemalloc-bookworm-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:3.3.2-jemalloc-bookworm
+docker pull quay.io/evl.ms/fullstaq-ruby:3.3.2-jemalloc-bullseye-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:3.3.2-jemalloc-bullseye
+docker pull quay.io/evl.ms/fullstaq-ruby:3.3.2-jemalloc-buster-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:3.3.2-jemalloc-buster
+docker pull quay.io/evl.ms/fullstaq-ruby:3.3.2-malloctrim-bookworm-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:3.3.2-malloctrim-bookworm
+docker pull quay.io/evl.ms/fullstaq-ruby:3.3.2-malloctrim-bullseye-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:3.3.2-malloctrim-bullseye
+docker pull quay.io/evl.ms/fullstaq-ruby:3.3.2-malloctrim-buster-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:3.3.2-malloctrim-buster
 
 # 3.2:
 docker pull quay.io/evl.ms/fullstaq-ruby:3.2.4-jemalloc-bookworm-slim
@@ -78,13 +78,13 @@ docker pull quay.io/evl.ms/fullstaq-ruby:3.0.7-malloctrim-buster-slim
 docker pull quay.io/evl.ms/fullstaq-ruby:3.0.7-malloctrim-buster
 ```
 
-Latest patch versions for Ruby 3.3 on Debian 12 (bookworm) are also aliased with shortened tags including major and minor versions only: `3.3.1-jemalloc-bookworm → 3.3-jemalloc`
+Latest patch versions for Ruby 3.3 on Debian 12 (bookworm) are also aliased with shortened tags including major and minor versions only: `3.3.2-jemalloc-bookworm → 3.3-jemalloc`
 
 ```sh
-docker pull quay.io/evl.ms/fullstaq-ruby:3.3-jemalloc-slim   # Same as quay.io/evl.ms/fullstaq-ruby:3.3.1-jemalloc-bookworm-slim
-docker pull quay.io/evl.ms/fullstaq-ruby:3.3-jemalloc        # Same as quay.io/evl.ms/fullstaq-ruby:3.3.1-jemalloc-bookworm
-docker pull quay.io/evl.ms/fullstaq-ruby:3.3-malloctrim-slim # Same as quay.io/evl.ms/fullstaq-ruby:3.3.1-malloctrim-bookworm-slim
-docker pull quay.io/evl.ms/fullstaq-ruby:3.3-malloctrim      # Same as quay.io/evl.ms/fullstaq-ruby:3.3.1-malloctrim-bookworm
+docker pull quay.io/evl.ms/fullstaq-ruby:3.3-jemalloc-slim   # Same as quay.io/evl.ms/fullstaq-ruby:3.3.2-jemalloc-bookworm-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:3.3-jemalloc        # Same as quay.io/evl.ms/fullstaq-ruby:3.3.2-jemalloc-bookworm
+docker pull quay.io/evl.ms/fullstaq-ruby:3.3-malloctrim-slim # Same as quay.io/evl.ms/fullstaq-ruby:3.3.2-malloctrim-bookworm-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:3.3-malloctrim      # Same as quay.io/evl.ms/fullstaq-ruby:3.3.2-malloctrim-bookworm
 ```
 
 For Ruby 3.2 and 3.1, short aliases for latest patch versions are made against Debian 11 (bullseye): `3.2.4-jemalloc-bullseye → 3.2-jemalloc`


### PR DESCRIPTION
Now that https://github.com/fullstaq-ruby/server-edition/pull/138 is merged, we can build the docker variants

Release notes:
* [ruby-lang.org/en/news/2024/05/29/ruby-3-1-6-released](https://www.ruby-lang.org/en/news/2024/05/29/ruby-3-1-6-released/)
* [ruby-lang.org/en/news/2024/05/30/ruby-3-3-2-released](https://www.ruby-lang.org/en/news/2024/05/30/ruby-3-3-2-released/)