### PR TITLE
Build Ruby 3.2.5

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -95,76 +95,76 @@ jobs:
             debian-image:   "buster-slim"
             debian-version: "10"
 
-          # 3.2.4 on Debian 12
-          - ruby-version:   "3.2.4"
+          # 3.2.5 on Debian 12
+          - ruby-version:   "3.2.5"
             ruby-variant:   "jemalloc"
             debian-image:   "bookworm"
             debian-version: "12"
             aliases: |
               quay.io/evl.ms/fullstaq-ruby:3.2-jemalloc-bookworm
-          - ruby-version:   "3.2.4"
+          - ruby-version:   "3.2.5"
             ruby-variant:   "jemalloc"
             debian-image:   "bookworm-slim"
             debian-version: "12"
             aliases: |
               quay.io/evl.ms/fullstaq-ruby:3.2-jemalloc-bookworm-slim
-          - ruby-version:   "3.2.4"
+          - ruby-version:   "3.2.5"
             ruby-variant:   "malloctrim"
             debian-image:   "bookworm"
             debian-version: "12"
             aliases: |
               quay.io/evl.ms/fullstaq-ruby:3.2-malloctrim-bookworm
-          - ruby-version:   "3.2.4"
+          - ruby-version:   "3.2.5"
             ruby-variant:   "malloctrim"
             debian-image:   "bookworm-slim"
             debian-version: "12"
             aliases: |
               quay.io/evl.ms/fullstaq-ruby:3.2-malloctrim-bookworm-slim
 
-          # 3.2.4 on Debian 11
-          - ruby-version:   "3.2.4"
+          # 3.2.5 on Debian 11
+          - ruby-version:   "3.2.5"
             ruby-variant:   "jemalloc"
             debian-image:   "bullseye"
             debian-version: "11"
             aliases:  |
-              quay.io/evl.ms/fullstaq-ruby:3.2.4-jemalloc
+              quay.io/evl.ms/fullstaq-ruby:3.2.5-jemalloc
               quay.io/evl.ms/fullstaq-ruby:3.2-jemalloc
-          - ruby-version:   "3.2.4"
+          - ruby-version:   "3.2.5"
             ruby-variant:   "jemalloc"
             debian-image:   "bullseye-slim"
             debian-version: "11"
             aliases: |
-              quay.io/evl.ms/fullstaq-ruby:3.2.4-jemalloc-slim
+              quay.io/evl.ms/fullstaq-ruby:3.2.5-jemalloc-slim
               quay.io/evl.ms/fullstaq-ruby:3.2-jemalloc-slim
-          - ruby-version:   "3.2.4"
+          - ruby-version:   "3.2.5"
             ruby-variant:   "malloctrim"
             debian-image:   "bullseye"
             debian-version: "11"
             aliases:  |
-              quay.io/evl.ms/fullstaq-ruby:3.2.4-malloctrim
+              quay.io/evl.ms/fullstaq-ruby:3.2.5-malloctrim
               quay.io/evl.ms/fullstaq-ruby:3.2-malloctrim
-          - ruby-version:   "3.2.4"
+          - ruby-version:   "3.2.5"
             ruby-variant:   "malloctrim"
             debian-image:   "bullseye-slim"
             debian-version: "11"
             aliases: |
-              quay.io/evl.ms/fullstaq-ruby:3.2.4-malloctrim-slim
+              quay.io/evl.ms/fullstaq-ruby:3.2.5-malloctrim-slim
               quay.io/evl.ms/fullstaq-ruby:3.2-malloctrim-slim
 
-          # 3.2.4 on Debian 10
-          - ruby-version:   "3.2.4"
+          # 3.2.5 on Debian 10
+          - ruby-version:   "3.2.5"
             ruby-variant:   "jemalloc"
             debian-image:   "buster"
             debian-version: "10"
-          - ruby-version:   "3.2.4"
+          - ruby-version:   "3.2.5"
             ruby-variant:   "jemalloc"
             debian-image:   "buster-slim"
             debian-version: "10"
-          - ruby-version:   "3.2.4"
+          - ruby-version:   "3.2.5"
             ruby-variant:   "malloctrim"
             debian-image:   "buster"
             debian-version: "10"
-          - ruby-version:   "3.2.4"
+          - ruby-version:   "3.2.5"
             ruby-variant:   "malloctrim"
             debian-image:   "buster-slim"
             debian-version: "10"

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ FROM quay.io/evl.ms/fullstaq-ruby:${RUBY_VERSION}-slim
 
 ## Flavors
 
-Ruby 3.3.4, 3.2.4, 3.1.6, and 3.0.7 with jemalloc and malloctrim are available. Images are built on top of Debian 10 (buster), 11 (bullseye), also Ruby 3.2 and newer are build on top of Debian 12 (bookworm):
+Ruby 3.3.4, 3.2.5, 3.1.6, and 3.0.7 with jemalloc and malloctrim are available. Images are built on top of Debian 10 (buster), 11 (bullseye), also Ruby 3.2 and newer are build on top of Debian 12 (bookworm):
 
 ```sh
 # 3.3:
@@ -44,18 +44,18 @@ docker pull quay.io/evl.ms/fullstaq-ruby:3.3.4-malloctrim-buster-slim
 docker pull quay.io/evl.ms/fullstaq-ruby:3.3.4-malloctrim-buster
 
 # 3.2:
-docker pull quay.io/evl.ms/fullstaq-ruby:3.2.4-jemalloc-bookworm-slim
-docker pull quay.io/evl.ms/fullstaq-ruby:3.2.4-jemalloc-bookworm
-docker pull quay.io/evl.ms/fullstaq-ruby:3.2.4-jemalloc-bullseye-slim
-docker pull quay.io/evl.ms/fullstaq-ruby:3.2.4-jemalloc-bullseye
-docker pull quay.io/evl.ms/fullstaq-ruby:3.2.4-jemalloc-buster-slim
-docker pull quay.io/evl.ms/fullstaq-ruby:3.2.4-jemalloc-buster
-docker pull quay.io/evl.ms/fullstaq-ruby:3.2.4-malloctrim-bookworm-slim
-docker pull quay.io/evl.ms/fullstaq-ruby:3.2.4-malloctrim-bookworm
-docker pull quay.io/evl.ms/fullstaq-ruby:3.2.4-malloctrim-bullseye-slim
-docker pull quay.io/evl.ms/fullstaq-ruby:3.2.4-malloctrim-bullseye
-docker pull quay.io/evl.ms/fullstaq-ruby:3.2.4-malloctrim-buster-slim
-docker pull quay.io/evl.ms/fullstaq-ruby:3.2.4-malloctrim-buster
+docker pull quay.io/evl.ms/fullstaq-ruby:3.2.5-jemalloc-bookworm-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:3.2.5-jemalloc-bookworm
+docker pull quay.io/evl.ms/fullstaq-ruby:3.2.5-jemalloc-bullseye-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:3.2.5-jemalloc-bullseye
+docker pull quay.io/evl.ms/fullstaq-ruby:3.2.5-jemalloc-buster-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:3.2.5-jemalloc-buster
+docker pull quay.io/evl.ms/fullstaq-ruby:3.2.5-malloctrim-bookworm-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:3.2.5-malloctrim-bookworm
+docker pull quay.io/evl.ms/fullstaq-ruby:3.2.5-malloctrim-bullseye-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:3.2.5-malloctrim-bullseye
+docker pull quay.io/evl.ms/fullstaq-ruby:3.2.5-malloctrim-buster-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:3.2.5-malloctrim-buster
 
 # 3.1:
 docker pull quay.io/evl.ms/fullstaq-ruby:3.1.6-jemalloc-bullseye-slim
@@ -87,7 +87,7 @@ docker pull quay.io/evl.ms/fullstaq-ruby:3.3-malloctrim-slim # Same as quay.io/e
 docker pull quay.io/evl.ms/fullstaq-ruby:3.3-malloctrim      # Same as quay.io/evl.ms/fullstaq-ruby:3.3.4-malloctrim-bookworm
 ```
 
-For Ruby 3.2 and 3.1, short aliases for latest patch versions are made against Debian 11 (bullseye): `3.2.4-jemalloc-bullseye → 3.2-jemalloc`
+For Ruby 3.2 and 3.1, short aliases for latest patch versions are made against Debian 11 (bullseye): `3.2.5-jemalloc-bullseye → 3.2-jemalloc`
 
 For Ruby 3.0, short aliases for latest patch versions are made against Debian 10 (buster): `3.0.7-jemalloc-buster → 3.0-jemalloc`
 


### PR DESCRIPTION
https://github.com/fullstaq-ruby/server-edition/pull/149 is merged

Release notes:

https://www.ruby-lang.org/en/news/2024/07/26/ruby-3-2-5-released/