### PR TITLE
Adds Ruby v3.4.1 & drops Ruby 3.0

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -17,6 +17,84 @@ jobs:
       matrix:
         include:
 
+          # 3.4.1 on Debian 12
+          - ruby-version:   "3.4.1"
+            ruby-variant:   "jemalloc"
+            debian-image:   "bookworm"
+            debian-version: "12"
+            aliases: |
+              quay.io/evl.ms/fullstaq-ruby:3.4-jemalloc
+              quay.io/evl.ms/fullstaq-ruby:3.4.1-jemalloc
+              quay.io/evl.ms/fullstaq-ruby:3.4-jemalloc-bookworm
+          - ruby-version:   "3.4.1"
+            ruby-variant:   "jemalloc"
+            debian-image:   "bookworm-slim"
+            debian-version: "12"
+            aliases: |
+              quay.io/evl.ms/fullstaq-ruby:3.4-jemalloc-slim
+              quay.io/evl.ms/fullstaq-ruby:3.4.1-jemalloc-slim
+              quay.io/evl.ms/fullstaq-ruby:3.4-jemalloc-bookworm-slim
+          - ruby-version:   "3.4.1"
+            ruby-variant:   "malloctrim"
+            debian-image:   "bookworm"
+            debian-version: "12"
+            aliases: |
+              quay.io/evl.ms/fullstaq-ruby:3.4-malloctrim
+              quay.io/evl.ms/fullstaq-ruby:3.4.1-malloctrim
+              quay.io/evl.ms/fullstaq-ruby:3.4-malloctrim-bookworm
+          - ruby-version:   "3.4.1"
+            ruby-variant:   "malloctrim"
+            debian-image:   "bookworm-slim"
+            debian-version: "12"
+            aliases: |
+              quay.io/evl.ms/fullstaq-ruby:3.4-malloctrim-slim
+              quay.io/evl.ms/fullstaq-ruby:3.4.1-malloctrim-slim
+              quay.io/evl.ms/fullstaq-ruby:3.4-malloctrim-bookworm-slim
+
+          # 3.4.1 on Debian 11
+          - ruby-version:   "3.4.1"
+            ruby-variant:   "jemalloc"
+            debian-image:   "bullseye"
+            debian-version: "11"
+            aliases: |
+              quay.io/evl.ms/fullstaq-ruby:3.4-jemalloc-bullseye
+          - ruby-version:   "3.4.1"
+            ruby-variant:   "jemalloc"
+            debian-image:   "bullseye-slim"
+            debian-version: "11"
+            aliases: |
+              quay.io/evl.ms/fullstaq-ruby:3.4-jemalloc-bullseye-slim
+          - ruby-version:   "3.4.1"
+            ruby-variant:   "malloctrim"
+            debian-image:   "bullseye"
+            debian-version: "11"
+            aliases: |
+              quay.io/evl.ms/fullstaq-ruby:3.4-malloctrim-bullseye
+          - ruby-version:   "3.4.1"
+            ruby-variant:   "malloctrim"
+            debian-image:   "bullseye-slim"
+            debian-version: "11"
+            aliases: |
+              quay.io/evl.ms/fullstaq-ruby:3.4-malloctrim-bullseye-slim
+
+          # 3.4.1 on Debian 10
+          - ruby-version:   "3.4.1"
+            ruby-variant:   "jemalloc"
+            debian-image:   "buster"
+            debian-version: "10"
+          - ruby-version:   "3.4.1"
+            ruby-variant:   "jemalloc"
+            debian-image:   "buster-slim"
+            debian-version: "10"
+          - ruby-version:   "3.4.1"
+            ruby-variant:   "malloctrim"
+            debian-image:   "buster"
+            debian-version: "10"
+          - ruby-version:   "3.4.1"
+            ruby-variant:   "malloctrim"
+            debian-image:   "buster-slim"
+            debian-version: "10"
+
           # 3.3.6 on Debian 12
           - ruby-version:   "3.3.6"
             ruby-variant:   "jemalloc"
@@ -216,54 +294,6 @@ jobs:
             ruby-variant:   "malloctrim"
             debian-image:   "buster-slim"
             debian-version: "10"
-
-          # 3.0.7 on Debian 11
-          - ruby-version:   "3.0.7"
-            ruby-variant:   "jemalloc"
-            debian-image:   "bullseye"
-            debian-version: "11"
-          - ruby-version:   "3.0.7"
-            ruby-variant:   "jemalloc"
-            debian-image:   "bullseye-slim"
-            debian-version: "11"
-          - ruby-version:   "3.0.7"
-            ruby-variant:   "malloctrim"
-            debian-image:   "bullseye"
-            debian-version: "11"
-          - ruby-version:   "3.0.7"
-            ruby-variant:   "malloctrim"
-            debian-image:   "bullseye-slim"
-            debian-version: "11"
-
-          # 3.0.7 on Debian 10
-          - ruby-version:   "3.0.7"
-            ruby-variant:   "jemalloc"
-            debian-image:   "buster"
-            debian-version: "10"
-            aliases:  |
-              quay.io/evl.ms/fullstaq-ruby:3.0.7-jemalloc
-              quay.io/evl.ms/fullstaq-ruby:3.0-jemalloc
-          - ruby-version:   "3.0.7"
-            ruby-variant:   "jemalloc"
-            debian-image:   "buster-slim"
-            debian-version: "10"
-            aliases: |
-              quay.io/evl.ms/fullstaq-ruby:3.0.7-jemalloc-slim
-              quay.io/evl.ms/fullstaq-ruby:3.0-jemalloc-slim
-          - ruby-version:   "3.0.7"
-            ruby-variant:   "malloctrim"
-            debian-image:   "buster"
-            debian-version: "10"
-            aliases:  |
-              quay.io/evl.ms/fullstaq-ruby:3.0.7-malloctrim
-              quay.io/evl.ms/fullstaq-ruby:3.0-malloctrim
-          - ruby-version:   "3.0.7"
-            ruby-variant:   "malloctrim"
-            debian-image:   "buster-slim"
-            debian-version: "10"
-            aliases: |
-              quay.io/evl.ms/fullstaq-ruby:3.0.7-malloctrim-slim
-              quay.io/evl.ms/fullstaq-ruby:3.0-malloctrim-slim
 
     steps:
       - name: Check out the repo

--- a/README.md
+++ b/README.md
@@ -13,22 +13,36 @@ These images are intended to be used while [Fullstaq] and [Hongli Lai] haven't b
 Pull it directly from the quay.io registry:
 
 ```sh
-docker pull quay.io/evl.ms/fullstaq-ruby:3.3-jemalloc-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:3.4-jemalloc-slim
 ```
 
 Or use as base image in your `Dockerfile`:
 
 ```docker
-ARG RUBY_VERSION=3.3.6-jemalloc
+ARG RUBY_VERSION=3.4.1-jemalloc
 
 FROM quay.io/evl.ms/fullstaq-ruby:${RUBY_VERSION}-slim
 ```
 
 ## Flavors
 
-Ruby 3.3.6, 3.2.6, 3.1.6, and 3.0.7 with jemalloc and malloctrim are available. Images are built on top of Debian 10 (buster), 11 (bullseye), also Ruby 3.2 and newer are build on top of Debian 12 (bookworm):
+Ruby 3.4.1, 3.3.6, 3.2.6 and 3.1.6 with jemalloc and malloctrim are available. Images are built on top of Debian 10 (buster), 11 (bullseye), also Ruby 3.2 and newer are build on top of Debian 12 (bookworm):
 
 ```sh
+# 3.4:
+docker pull quay.io/evl.ms/fullstaq-ruby:3.4.1-jemalloc-bookworm-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:3.4.1-jemalloc-bookworm
+docker pull quay.io/evl.ms/fullstaq-ruby:3.4.1-jemalloc-bullseye-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:3.4.1-jemalloc-bullseye
+docker pull quay.io/evl.ms/fullstaq-ruby:3.4.1-jemalloc-buster-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:3.4.1-jemalloc-buster
+docker pull quay.io/evl.ms/fullstaq-ruby:3.4.1-malloctrim-bookworm-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:3.4.1-malloctrim-bookworm
+docker pull quay.io/evl.ms/fullstaq-ruby:3.4.1-malloctrim-bullseye-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:3.4.1-malloctrim-bullseye
+docker pull quay.io/evl.ms/fullstaq-ruby:3.4.1-malloctrim-buster-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:3.4.1-malloctrim-buster
+
 # 3.3:
 docker pull quay.io/evl.ms/fullstaq-ruby:3.3.6-jemalloc-bookworm-slim
 docker pull quay.io/evl.ms/fullstaq-ruby:3.3.6-jemalloc-bookworm
@@ -66,31 +80,18 @@ docker pull quay.io/evl.ms/fullstaq-ruby:3.1.6-malloctrim-bullseye-slim
 docker pull quay.io/evl.ms/fullstaq-ruby:3.1.6-malloctrim-bullseye
 docker pull quay.io/evl.ms/fullstaq-ruby:3.1.6-malloctrim-buster-slim
 docker pull quay.io/evl.ms/fullstaq-ruby:3.1.6-malloctrim-buster
-
-# 3.0:
-docker pull quay.io/evl.ms/fullstaq-ruby:3.0.7-jemalloc-bullseye-slim
-docker pull quay.io/evl.ms/fullstaq-ruby:3.0.7-jemalloc-bullseye
-docker pull quay.io/evl.ms/fullstaq-ruby:3.0.7-jemalloc-buster-slim
-docker pull quay.io/evl.ms/fullstaq-ruby:3.0.7-jemalloc-buster
-docker pull quay.io/evl.ms/fullstaq-ruby:3.0.7-malloctrim-bullseye-slim
-docker pull quay.io/evl.ms/fullstaq-ruby:3.0.7-malloctrim-bullseye
-docker pull quay.io/evl.ms/fullstaq-ruby:3.0.7-malloctrim-buster-slim
-docker pull quay.io/evl.ms/fullstaq-ruby:3.0.7-malloctrim-buster
 ```
 
-Latest patch versions for Ruby 3.3 on Debian 12 (bookworm) are also aliased with shortened tags including major and minor versions only: `3.3.6-jemalloc-bookworm → 3.3-jemalloc`
+Latest patch versions for Ruby 3.4 on Debian 12 (bookworm) are also aliased with shortened tags including major and minor versions only: `3.4.1-jemalloc-bookworm → 3.4-jemalloc`
 
 ```sh
-docker pull quay.io/evl.ms/fullstaq-ruby:3.3-jemalloc-slim   # Same as quay.io/evl.ms/fullstaq-ruby:3.3.6-jemalloc-bookworm-slim
-docker pull quay.io/evl.ms/fullstaq-ruby:3.3-jemalloc        # Same as quay.io/evl.ms/fullstaq-ruby:3.3.6-jemalloc-bookworm
-docker pull quay.io/evl.ms/fullstaq-ruby:3.3-malloctrim-slim # Same as quay.io/evl.ms/fullstaq-ruby:3.3.6-malloctrim-bookworm-slim
-docker pull quay.io/evl.ms/fullstaq-ruby:3.3-malloctrim      # Same as quay.io/evl.ms/fullstaq-ruby:3.3.6-malloctrim-bookworm
+docker pull quay.io/evl.ms/fullstaq-ruby:3.4-jemalloc-slim   # Same as quay.io/evl.ms/fullstaq-ruby:3.4.1-jemalloc-bookworm-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:3.4-jemalloc        # Same as quay.io/evl.ms/fullstaq-ruby:3.4.1-jemalloc-bookworm
+docker pull quay.io/evl.ms/fullstaq-ruby:3.4-malloctrim-slim # Same as quay.io/evl.ms/fullstaq-ruby:3.4.1-malloctrim-bookworm-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:3.4-malloctrim      # Same as quay.io/evl.ms/fullstaq-ruby:3.4.1-malloctrim-bookworm
 ```
 
 For Ruby 3.2 and 3.1, short aliases for latest patch versions are made against Debian 11 (bullseye): `3.2.6-jemalloc-bullseye → 3.2-jemalloc`
-
-For Ruby 3.0, short aliases for latest patch versions are made against Debian 10 (buster): `3.0.7-jemalloc-buster → 3.0-jemalloc`
-
 
 ## Details
 


### PR DESCRIPTION
Now https://github.com/fullstaq-ruby/server-edition/pull/157 is merged