### PR TITLE
Build Ruby 3.4.5

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -17,80 +17,80 @@ jobs:
       matrix:
         include:
 
-          # 3.4.4 on Debian 12
-          - ruby-version:   "3.4.4"
+          # 3.4.5 on Debian 12
+          - ruby-version:   "3.4.5"
             ruby-variant:   "jemalloc"
             debian-image:   "bookworm"
             debian-version: "12"
             aliases: |
               quay.io/evl.ms/fullstaq-ruby:3.4-jemalloc
-              quay.io/evl.ms/fullstaq-ruby:3.4.4-jemalloc
+              quay.io/evl.ms/fullstaq-ruby:3.4.5-jemalloc
               quay.io/evl.ms/fullstaq-ruby:3.4-jemalloc-bookworm
-          - ruby-version:   "3.4.4"
+          - ruby-version:   "3.4.5"
             ruby-variant:   "jemalloc"
             debian-image:   "bookworm-slim"
             debian-version: "12"
             aliases: |
               quay.io/evl.ms/fullstaq-ruby:3.4-jemalloc-slim
-              quay.io/evl.ms/fullstaq-ruby:3.4.4-jemalloc-slim
+              quay.io/evl.ms/fullstaq-ruby:3.4.5-jemalloc-slim
               quay.io/evl.ms/fullstaq-ruby:3.4-jemalloc-bookworm-slim
-          - ruby-version:   "3.4.4"
+          - ruby-version:   "3.4.5"
             ruby-variant:   "malloctrim"
             debian-image:   "bookworm"
             debian-version: "12"
             aliases: |
               quay.io/evl.ms/fullstaq-ruby:3.4-malloctrim
-              quay.io/evl.ms/fullstaq-ruby:3.4.4-malloctrim
+              quay.io/evl.ms/fullstaq-ruby:3.4.5-malloctrim
               quay.io/evl.ms/fullstaq-ruby:3.4-malloctrim-bookworm
-          - ruby-version:   "3.4.4"
+          - ruby-version:   "3.4.5"
             ruby-variant:   "malloctrim"
             debian-image:   "bookworm-slim"
             debian-version: "12"
             aliases: |
               quay.io/evl.ms/fullstaq-ruby:3.4-malloctrim-slim
-              quay.io/evl.ms/fullstaq-ruby:3.4.4-malloctrim-slim
+              quay.io/evl.ms/fullstaq-ruby:3.4.5-malloctrim-slim
               quay.io/evl.ms/fullstaq-ruby:3.4-malloctrim-bookworm-slim
 
-          # 3.4.4 on Debian 11
-          - ruby-version:   "3.4.4"
+          # 3.4.5 on Debian 11
+          - ruby-version:   "3.4.5"
             ruby-variant:   "jemalloc"
             debian-image:   "bullseye"
             debian-version: "11"
             aliases: |
               quay.io/evl.ms/fullstaq-ruby:3.4-jemalloc-bullseye
-          - ruby-version:   "3.4.4"
+          - ruby-version:   "3.4.5"
             ruby-variant:   "jemalloc"
             debian-image:   "bullseye-slim"
             debian-version: "11"
             aliases: |
               quay.io/evl.ms/fullstaq-ruby:3.4-jemalloc-bullseye-slim
-          - ruby-version:   "3.4.4"
+          - ruby-version:   "3.4.5"
             ruby-variant:   "malloctrim"
             debian-image:   "bullseye"
             debian-version: "11"
             aliases: |
               quay.io/evl.ms/fullstaq-ruby:3.4-malloctrim-bullseye
-          - ruby-version:   "3.4.4"
+          - ruby-version:   "3.4.5"
             ruby-variant:   "malloctrim"
             debian-image:   "bullseye-slim"
             debian-version: "11"
             aliases: |
               quay.io/evl.ms/fullstaq-ruby:3.4-malloctrim-bullseye-slim
 
-          # 3.4.4 on Debian 10
-          - ruby-version:   "3.4.4"
+          # 3.4.5 on Debian 10
+          - ruby-version:   "3.4.5"
             ruby-variant:   "jemalloc"
             debian-image:   "buster"
             debian-version: "10"
-          - ruby-version:   "3.4.4"
+          - ruby-version:   "3.4.5"
             ruby-variant:   "jemalloc"
             debian-image:   "buster-slim"
             debian-version: "10"
-          - ruby-version:   "3.4.4"
+          - ruby-version:   "3.4.5"
             ruby-variant:   "malloctrim"
             debian-image:   "buster"
             debian-version: "10"
-          - ruby-version:   "3.4.4"
+          - ruby-version:   "3.4.5"
             ruby-variant:   "malloctrim"
             debian-image:   "buster-slim"
             debian-version: "10"

--- a/README.md
+++ b/README.md
@@ -19,29 +19,29 @@ docker pull quay.io/evl.ms/fullstaq-ruby:3.4-jemalloc-slim
 Or use as base image in your `Dockerfile`:
 
 ```docker
-ARG RUBY_VERSION=3.4.4-jemalloc
+ARG RUBY_VERSION=3.4.5-jemalloc
 
 FROM quay.io/evl.ms/fullstaq-ruby:${RUBY_VERSION}-slim
 ```
 
 ## Flavors
 
-Ruby 3.4.4, 3.3.8, 3.2.8 and 3.1.7 with jemalloc and malloctrim are available. Images are built on top of Debian 10 (buster), 11 (bullseye), also Ruby 3.2 and newer are build on top of Debian 12 (bookworm):
+Ruby 3.4.5, 3.3.8, 3.2.8 and 3.1.7 with jemalloc and malloctrim are available. Images are built on top of Debian 10 (buster), 11 (bullseye), also Ruby 3.2 and newer are build on top of Debian 12 (bookworm):
 
 ```sh
 # 3.4:
-docker pull quay.io/evl.ms/fullstaq-ruby:3.4.4-jemalloc-bookworm-slim
-docker pull quay.io/evl.ms/fullstaq-ruby:3.4.4-jemalloc-bookworm
-docker pull quay.io/evl.ms/fullstaq-ruby:3.4.4-jemalloc-bullseye-slim
-docker pull quay.io/evl.ms/fullstaq-ruby:3.4.4-jemalloc-bullseye
-docker pull quay.io/evl.ms/fullstaq-ruby:3.4.4-jemalloc-buster-slim
-docker pull quay.io/evl.ms/fullstaq-ruby:3.4.4-jemalloc-buster
-docker pull quay.io/evl.ms/fullstaq-ruby:3.4.4-malloctrim-bookworm-slim
-docker pull quay.io/evl.ms/fullstaq-ruby:3.4.4-malloctrim-bookworm
-docker pull quay.io/evl.ms/fullstaq-ruby:3.4.4-malloctrim-bullseye-slim
-docker pull quay.io/evl.ms/fullstaq-ruby:3.4.4-malloctrim-bullseye
-docker pull quay.io/evl.ms/fullstaq-ruby:3.4.4-malloctrim-buster-slim
-docker pull quay.io/evl.ms/fullstaq-ruby:3.4.4-malloctrim-buster
+docker pull quay.io/evl.ms/fullstaq-ruby:3.4.5-jemalloc-bookworm-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:3.4.5-jemalloc-bookworm
+docker pull quay.io/evl.ms/fullstaq-ruby:3.4.5-jemalloc-bullseye-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:3.4.5-jemalloc-bullseye
+docker pull quay.io/evl.ms/fullstaq-ruby:3.4.5-jemalloc-buster-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:3.4.5-jemalloc-buster
+docker pull quay.io/evl.ms/fullstaq-ruby:3.4.5-malloctrim-bookworm-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:3.4.5-malloctrim-bookworm
+docker pull quay.io/evl.ms/fullstaq-ruby:3.4.5-malloctrim-bullseye-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:3.4.5-malloctrim-bullseye
+docker pull quay.io/evl.ms/fullstaq-ruby:3.4.5-malloctrim-buster-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:3.4.5-malloctrim-buster
 
 # 3.3:
 docker pull quay.io/evl.ms/fullstaq-ruby:3.3.8-jemalloc-bookworm-slim
@@ -82,13 +82,13 @@ docker pull quay.io/evl.ms/fullstaq-ruby:3.1.7-malloctrim-buster-slim
 docker pull quay.io/evl.ms/fullstaq-ruby:3.1.7-malloctrim-buster
 ```
 
-Latest patch versions for Ruby 3.4 on Debian 12 (bookworm) are also aliased with shortened tags including major and minor versions only: `3.4.4-jemalloc-bookworm → 3.4-jemalloc`
+Latest patch versions for Ruby 3.4 on Debian 12 (bookworm) are also aliased with shortened tags including major and minor versions only: `3.4.5-jemalloc-bookworm → 3.4-jemalloc`
 
 ```sh
-docker pull quay.io/evl.ms/fullstaq-ruby:3.4-jemalloc-slim   # Same as quay.io/evl.ms/fullstaq-ruby:3.4.4-jemalloc-bookworm-slim
-docker pull quay.io/evl.ms/fullstaq-ruby:3.4-jemalloc        # Same as quay.io/evl.ms/fullstaq-ruby:3.4.4-jemalloc-bookworm
-docker pull quay.io/evl.ms/fullstaq-ruby:3.4-malloctrim-slim # Same as quay.io/evl.ms/fullstaq-ruby:3.4.4-malloctrim-bookworm-slim
-docker pull quay.io/evl.ms/fullstaq-ruby:3.4-malloctrim      # Same as quay.io/evl.ms/fullstaq-ruby:3.4.4-malloctrim-bookworm
+docker pull quay.io/evl.ms/fullstaq-ruby:3.4-jemalloc-slim   # Same as quay.io/evl.ms/fullstaq-ruby:3.4.5-jemalloc-bookworm-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:3.4-jemalloc        # Same as quay.io/evl.ms/fullstaq-ruby:3.4.5-jemalloc-bookworm
+docker pull quay.io/evl.ms/fullstaq-ruby:3.4-malloctrim-slim # Same as quay.io/evl.ms/fullstaq-ruby:3.4.5-malloctrim-bookworm-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:3.4-malloctrim      # Same as quay.io/evl.ms/fullstaq-ruby:3.4.5-malloctrim-bookworm
 ```
 
 For Ruby 3.2 and 3.1, short aliases for latest patch versions are made against Debian 11 (bullseye): `3.2.8-jemalloc-bullseye → 3.2-jemalloc`


### PR DESCRIPTION
https://www.ruby-lang.org/en/news/2025/07/15/ruby-3-4-5-released/