### PR TITLE
Build Ruby 3.3.10

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -103,86 +103,86 @@ jobs:
             aliases: |
               quay.io/evl.ms/fullstaq-ruby:3.4-malloctrim-bullseye-slim
 
-          # 3.3.9 on Debian 13
-          - ruby-version:   "3.3.9"
+          # 3.3.10 on Debian 13
+          - ruby-version:   "3.3.10"
             ruby-variant:   "jemalloc"
             debian-image:   "trixie"
             debian-version: "13"
             aliases: |
               quay.io/evl.ms/fullstaq-ruby:3.3-jemalloc-trixie
-          - ruby-version:   "3.3.9"
+          - ruby-version:   "3.3.10"
             ruby-variant:   "jemalloc"
             debian-image:   "trixie-slim"
             debian-version: "13"
             aliases: |
               quay.io/evl.ms/fullstaq-ruby:3.3-jemalloc-trixie-slim
-          - ruby-version:   "3.3.9"
+          - ruby-version:   "3.3.10"
             ruby-variant:   "malloctrim"
             debian-image:   "trixie"
             debian-version: "13"
             aliases: |
               quay.io/evl.ms/fullstaq-ruby:3.3-malloctrim-trixie
-          - ruby-version:   "3.3.9"
+          - ruby-version:   "3.3.10"
             ruby-variant:   "malloctrim"
             debian-image:   "trixie-slim"
             debian-version: "13"
             aliases: |
               quay.io/evl.ms/fullstaq-ruby:3.3-malloctrim-trixie-slim
 
-          # 3.3.9 on Debian 12
-          - ruby-version:   "3.3.9"
+          # 3.3.10 on Debian 12
+          - ruby-version:   "3.3.10"
             ruby-variant:   "jemalloc"
             debian-image:   "bookworm"
             debian-version: "12"
             aliases: |
               quay.io/evl.ms/fullstaq-ruby:3.3-jemalloc
-              quay.io/evl.ms/fullstaq-ruby:3.3.9-jemalloc
+              quay.io/evl.ms/fullstaq-ruby:3.3.10-jemalloc
               quay.io/evl.ms/fullstaq-ruby:3.3-jemalloc-bookworm
-          - ruby-version:   "3.3.9"
+          - ruby-version:   "3.3.10"
             ruby-variant:   "jemalloc"
             debian-image:   "bookworm-slim"
             debian-version: "12"
             aliases: |
               quay.io/evl.ms/fullstaq-ruby:3.3-jemalloc-slim
-              quay.io/evl.ms/fullstaq-ruby:3.3.9-jemalloc-slim
+              quay.io/evl.ms/fullstaq-ruby:3.3.10-jemalloc-slim
               quay.io/evl.ms/fullstaq-ruby:3.3-jemalloc-bookworm-slim
-          - ruby-version:   "3.3.9"
+          - ruby-version:   "3.3.10"
             ruby-variant:   "malloctrim"
             debian-image:   "bookworm"
             debian-version: "12"
             aliases: |
               quay.io/evl.ms/fullstaq-ruby:3.3-malloctrim
-              quay.io/evl.ms/fullstaq-ruby:3.3.9-malloctrim
+              quay.io/evl.ms/fullstaq-ruby:3.3.10-malloctrim
               quay.io/evl.ms/fullstaq-ruby:3.3-malloctrim-bookworm
-          - ruby-version:   "3.3.9"
+          - ruby-version:   "3.3.10"
             ruby-variant:   "malloctrim"
             debian-image:   "bookworm-slim"
             debian-version: "12"
             aliases: |
               quay.io/evl.ms/fullstaq-ruby:3.3-malloctrim-slim
-              quay.io/evl.ms/fullstaq-ruby:3.3.9-malloctrim-slim
+              quay.io/evl.ms/fullstaq-ruby:3.3.10-malloctrim-slim
               quay.io/evl.ms/fullstaq-ruby:3.3-malloctrim-bookworm-slim
 
-          # 3.3.9 on Debian 11
-          - ruby-version:   "3.3.9"
+          # 3.3.10 on Debian 11
+          - ruby-version:   "3.3.10"
             ruby-variant:   "jemalloc"
             debian-image:   "bullseye"
             debian-version: "11"
             aliases: |
               quay.io/evl.ms/fullstaq-ruby:3.3-jemalloc-bullseye
-          - ruby-version:   "3.3.9"
+          - ruby-version:   "3.3.10"
             ruby-variant:   "jemalloc"
             debian-image:   "bullseye-slim"
             debian-version: "11"
             aliases: |
               quay.io/evl.ms/fullstaq-ruby:3.3-jemalloc-bullseye-slim
-          - ruby-version:   "3.3.9"
+          - ruby-version:   "3.3.10"
             ruby-variant:   "malloctrim"
             debian-image:   "bullseye"
             debian-version: "11"
             aliases: |
               quay.io/evl.ms/fullstaq-ruby:3.3-malloctrim-bullseye
-          - ruby-version:   "3.3.9"
+          - ruby-version:   "3.3.10"
             ruby-variant:   "malloctrim"
             debian-image:   "bullseye-slim"
             debian-version: "11"

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ FROM quay.io/evl.ms/fullstaq-ruby:${RUBY_VERSION}-slim
 
 ## Flavors
 
-Ruby 3.4.7, 3.3.9, 3.2.9, and 3.1.7 with jemalloc and malloctrim are available. Images are built on top of Debian 11 (bullseye), 12 (bookworm), 13 (trixie):
+Ruby 3.4.7, 3.3.10, 3.2.9, and 3.1.7 with jemalloc and malloctrim are available. Images are built on top of Debian 11 (bullseye), 12 (bookworm), 13 (trixie):
 
 ```sh
 # 3.4:
@@ -42,16 +42,16 @@ docker pull quay.io/evl.ms/fullstaq-ruby:3.4.7-malloctrim-bullseye-slim
 docker pull quay.io/evl.ms/fullstaq-ruby:3.4.7-malloctrim-bullseye
 
 # 3.3:
-docker pull quay.io/evl.ms/fullstaq-ruby:3.3.9-jemalloc-trixie-slim
-docker pull quay.io/evl.ms/fullstaq-ruby:3.3.9-jemalloc-trixie
-docker pull quay.io/evl.ms/fullstaq-ruby:3.3.9-jemalloc-bookworm-slim
-docker pull quay.io/evl.ms/fullstaq-ruby:3.3.9-jemalloc-bookworm
-docker pull quay.io/evl.ms/fullstaq-ruby:3.3.9-jemalloc-bullseye-slim
-docker pull quay.io/evl.ms/fullstaq-ruby:3.3.9-jemalloc-bullseye
-docker pull quay.io/evl.ms/fullstaq-ruby:3.3.9-malloctrim-bookworm-slim
-docker pull quay.io/evl.ms/fullstaq-ruby:3.3.9-malloctrim-bookworm
-docker pull quay.io/evl.ms/fullstaq-ruby:3.3.9-malloctrim-bullseye-slim
-docker pull quay.io/evl.ms/fullstaq-ruby:3.3.9-malloctrim-bullseye
+docker pull quay.io/evl.ms/fullstaq-ruby:3.3.10-jemalloc-trixie-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:3.3.10-jemalloc-trixie
+docker pull quay.io/evl.ms/fullstaq-ruby:3.3.10-jemalloc-bookworm-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:3.3.10-jemalloc-bookworm
+docker pull quay.io/evl.ms/fullstaq-ruby:3.3.10-jemalloc-bullseye-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:3.3.10-jemalloc-bullseye
+docker pull quay.io/evl.ms/fullstaq-ruby:3.3.10-malloctrim-bookworm-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:3.3.10-malloctrim-bookworm
+docker pull quay.io/evl.ms/fullstaq-ruby:3.3.10-malloctrim-bullseye-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:3.3.10-malloctrim-bullseye
 
 # 3.2:
 docker pull quay.io/evl.ms/fullstaq-ruby:3.2.9-jemalloc-bookworm-slim


### PR DESCRIPTION
https://www.ruby-lang.org/en/news/2025/10/23/ruby-3-3-10-released/
https://github.com/fullstaq-ruby/server-edition/commit/a122ddd1920328eb465510cd249d9095b161eaff