### PR TITLE
Build Ruby 3.4.8

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -17,86 +17,86 @@ jobs:
       matrix:
         include:
 
-          # 3.4.7 on Debian 13
-          - ruby-version:   "3.4.7"
+          # 3.4.8 on Debian 13
+          - ruby-version:   "3.4.8"
             ruby-variant:   "jemalloc"
             debian-image:   "trixie"
             debian-version: "13"
             aliases: |
               quay.io/evl.ms/fullstaq-ruby:3.4-jemalloc-trixie
-          - ruby-version:   "3.4.7"
+          - ruby-version:   "3.4.8"
             ruby-variant:   "jemalloc"
             debian-image:   "trixie-slim"
             debian-version: "13"
             aliases: |
               quay.io/evl.ms/fullstaq-ruby:3.4-jemalloc-trixie-slim
-          - ruby-version:   "3.4.7"
+          - ruby-version:   "3.4.8"
             ruby-variant:   "malloctrim"
             debian-image:   "trixie"
             debian-version: "13"
             aliases: |
               quay.io/evl.ms/fullstaq-ruby:3.4-malloctrim-trixie
-          - ruby-version:   "3.4.7"
+          - ruby-version:   "3.4.8"
             ruby-variant:   "malloctrim"
             debian-image:   "trixie-slim"
             debian-version: "13"
             aliases: |
               quay.io/evl.ms/fullstaq-ruby:3.4-malloctrim-trixie-slim
 
-          # 3.4.7 on Debian 12
-          - ruby-version:   "3.4.7"
+          # 3.4.8 on Debian 12
+          - ruby-version:   "3.4.8"
             ruby-variant:   "jemalloc"
             debian-image:   "bookworm"
             debian-version: "12"
             aliases: |
               quay.io/evl.ms/fullstaq-ruby:3.4-jemalloc
-              quay.io/evl.ms/fullstaq-ruby:3.4.7-jemalloc
+              quay.io/evl.ms/fullstaq-ruby:3.4.8-jemalloc
               quay.io/evl.ms/fullstaq-ruby:3.4-jemalloc-bookworm
-          - ruby-version:   "3.4.7"
+          - ruby-version:   "3.4.8"
             ruby-variant:   "jemalloc"
             debian-image:   "bookworm-slim"
             debian-version: "12"
             aliases: |
               quay.io/evl.ms/fullstaq-ruby:3.4-jemalloc-slim
-              quay.io/evl.ms/fullstaq-ruby:3.4.7-jemalloc-slim
+              quay.io/evl.ms/fullstaq-ruby:3.4.8-jemalloc-slim
               quay.io/evl.ms/fullstaq-ruby:3.4-jemalloc-bookworm-slim
-          - ruby-version:   "3.4.7"
+          - ruby-version:   "3.4.8"
             ruby-variant:   "malloctrim"
             debian-image:   "bookworm"
             debian-version: "12"
             aliases: |
               quay.io/evl.ms/fullstaq-ruby:3.4-malloctrim
-              quay.io/evl.ms/fullstaq-ruby:3.4.7-malloctrim
+              quay.io/evl.ms/fullstaq-ruby:3.4.8-malloctrim
               quay.io/evl.ms/fullstaq-ruby:3.4-malloctrim-bookworm
-          - ruby-version:   "3.4.7"
+          - ruby-version:   "3.4.8"
             ruby-variant:   "malloctrim"
             debian-image:   "bookworm-slim"
             debian-version: "12"
             aliases: |
               quay.io/evl.ms/fullstaq-ruby:3.4-malloctrim-slim
-              quay.io/evl.ms/fullstaq-ruby:3.4.7-malloctrim-slim
+              quay.io/evl.ms/fullstaq-ruby:3.4.8-malloctrim-slim
               quay.io/evl.ms/fullstaq-ruby:3.4-malloctrim-bookworm-slim
 
-          # 3.4.7 on Debian 11
-          - ruby-version:   "3.4.7"
+          # 3.4.8 on Debian 11
+          - ruby-version:   "3.4.8"
             ruby-variant:   "jemalloc"
             debian-image:   "bullseye"
             debian-version: "11"
             aliases: |
               quay.io/evl.ms/fullstaq-ruby:3.4-jemalloc-bullseye
-          - ruby-version:   "3.4.7"
+          - ruby-version:   "3.4.8"
             ruby-variant:   "jemalloc"
             debian-image:   "bullseye-slim"
             debian-version: "11"
             aliases: |
               quay.io/evl.ms/fullstaq-ruby:3.4-jemalloc-bullseye-slim
-          - ruby-version:   "3.4.7"
+          - ruby-version:   "3.4.8"
             ruby-variant:   "malloctrim"
             debian-image:   "bullseye"
             debian-version: "11"
             aliases: |
               quay.io/evl.ms/fullstaq-ruby:3.4-malloctrim-bullseye
-          - ruby-version:   "3.4.7"
+          - ruby-version:   "3.4.8"
             ruby-variant:   "malloctrim"
             debian-image:   "bullseye-slim"
             debian-version: "11"

--- a/README.md
+++ b/README.md
@@ -19,27 +19,27 @@ docker pull quay.io/evl.ms/fullstaq-ruby:3.4-jemalloc-slim
 Or use as base image in your `Dockerfile`:
 
 ```docker
-ARG RUBY_VERSION=3.4.7-jemalloc
+ARG RUBY_VERSION=3.4.8-jemalloc
 
 FROM quay.io/evl.ms/fullstaq-ruby:${RUBY_VERSION}-slim
 ```
 
 ## Flavors
 
-Ruby 3.4.7, 3.3.10, 3.2.9, and 3.1.7 with jemalloc and malloctrim are available. Images are built on top of Debian 11 (bullseye), 12 (bookworm), 13 (trixie):
+Ruby 3.4.8, 3.3.10, 3.2.9, and 3.1.7 with jemalloc and malloctrim are available. Images are built on top of Debian 11 (bullseye), 12 (bookworm), 13 (trixie):
 
 ```sh
 # 3.4:
-docker pull quay.io/evl.ms/fullstaq-ruby:3.4.7-jemalloc-trixie-slim
-docker pull quay.io/evl.ms/fullstaq-ruby:3.4.7-jemalloc-trixie
-docker pull quay.io/evl.ms/fullstaq-ruby:3.4.7-jemalloc-bookworm-slim
-docker pull quay.io/evl.ms/fullstaq-ruby:3.4.7-jemalloc-bookworm
-docker pull quay.io/evl.ms/fullstaq-ruby:3.4.7-jemalloc-bullseye-slim
-docker pull quay.io/evl.ms/fullstaq-ruby:3.4.7-jemalloc-bullseye
-docker pull quay.io/evl.ms/fullstaq-ruby:3.4.7-malloctrim-bookworm-slim
-docker pull quay.io/evl.ms/fullstaq-ruby:3.4.7-malloctrim-bookworm
-docker pull quay.io/evl.ms/fullstaq-ruby:3.4.7-malloctrim-bullseye-slim
-docker pull quay.io/evl.ms/fullstaq-ruby:3.4.7-malloctrim-bullseye
+docker pull quay.io/evl.ms/fullstaq-ruby:3.4.8-jemalloc-trixie-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:3.4.8-jemalloc-trixie
+docker pull quay.io/evl.ms/fullstaq-ruby:3.4.8-jemalloc-bookworm-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:3.4.8-jemalloc-bookworm
+docker pull quay.io/evl.ms/fullstaq-ruby:3.4.8-jemalloc-bullseye-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:3.4.8-jemalloc-bullseye
+docker pull quay.io/evl.ms/fullstaq-ruby:3.4.8-malloctrim-bookworm-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:3.4.8-malloctrim-bookworm
+docker pull quay.io/evl.ms/fullstaq-ruby:3.4.8-malloctrim-bullseye-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:3.4.8-malloctrim-bullseye
 
 # 3.3:
 docker pull quay.io/evl.ms/fullstaq-ruby:3.3.10-jemalloc-trixie-slim
@@ -70,13 +70,13 @@ docker pull quay.io/evl.ms/fullstaq-ruby:3.1.7-malloctrim-bullseye-slim
 docker pull quay.io/evl.ms/fullstaq-ruby:3.1.7-malloctrim-bullseye
 ```
 
-Latest patch versions for Ruby 3.4 on Debian 12 (bookworm) are also aliased with shortened tags including major and minor versions only: `3.4.7-jemalloc-bookworm → 3.4-jemalloc`
+Latest patch versions for Ruby 3.4 on Debian 12 (bookworm) are also aliased with shortened tags including major and minor versions only: `3.4.8-jemalloc-bookworm → 3.4-jemalloc`
 
 ```sh
-docker pull quay.io/evl.ms/fullstaq-ruby:3.4-jemalloc-slim   # Same as quay.io/evl.ms/fullstaq-ruby:3.4.7-jemalloc-bookworm-slim
-docker pull quay.io/evl.ms/fullstaq-ruby:3.4-jemalloc        # Same as quay.io/evl.ms/fullstaq-ruby:3.4.7-jemalloc-bookworm
-docker pull quay.io/evl.ms/fullstaq-ruby:3.4-malloctrim-slim # Same as quay.io/evl.ms/fullstaq-ruby:3.4.7-malloctrim-bookworm-slim
-docker pull quay.io/evl.ms/fullstaq-ruby:3.4-malloctrim      # Same as quay.io/evl.ms/fullstaq-ruby:3.4.7-malloctrim-bookworm
+docker pull quay.io/evl.ms/fullstaq-ruby:3.4-jemalloc-slim   # Same as quay.io/evl.ms/fullstaq-ruby:3.4.8-jemalloc-bookworm-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:3.4-jemalloc        # Same as quay.io/evl.ms/fullstaq-ruby:3.4.8-jemalloc-bookworm
+docker pull quay.io/evl.ms/fullstaq-ruby:3.4-malloctrim-slim # Same as quay.io/evl.ms/fullstaq-ruby:3.4.8-malloctrim-bookworm-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:3.4-malloctrim      # Same as quay.io/evl.ms/fullstaq-ruby:3.4.8-malloctrim-bookworm
 ```
 
 For Ruby 3.2 and 3.1, short aliases for latest patch versions are made against Debian 11 (bullseye): `3.2.9-jemalloc-bullseye → 3.2-jemalloc`


### PR DESCRIPTION
https://www.ruby-lang.org/en/news/2025/12/17/ruby-3-4-8-released/

https://github.com/fullstaq-ruby/server-edition/pull/181 merged