### PR TITLE
Build Ruby 4.0.3, 3.4.9, 3.3.11, 3.2.11 and drop 3.1.7

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -17,263 +17,293 @@ jobs:
       matrix:
         include:
 
-          # 3.4.8 on Debian 13
-          - ruby-version:   "3.4.8"
+          # 4.0.3 on Debian 13
+          - ruby-version:   "4.0.3"
+            ruby-variant:   "jemalloc"
+            debian-image:   "trixie"
+            debian-version: "13"
+            aliases: |
+              quay.io/evl.ms/fullstaq-ruby:4.0-jemalloc
+              quay.io/evl.ms/fullstaq-ruby:4.0.3-jemalloc
+              quay.io/evl.ms/fullstaq-ruby:4.0-jemalloc-trixie
+          - ruby-version:   "4.0.3"
+            ruby-variant:   "jemalloc"
+            debian-image:   "trixie-slim"
+            debian-version: "13"
+            aliases: |
+              quay.io/evl.ms/fullstaq-ruby:4.0-jemalloc-slim
+              quay.io/evl.ms/fullstaq-ruby:4.0.3-jemalloc-slim
+              quay.io/evl.ms/fullstaq-ruby:4.0-jemalloc-trixie-slim
+          - ruby-version:   "4.0.3"
+            ruby-variant:   "malloctrim"
+            debian-image:   "trixie"
+            debian-version: "13"
+            aliases: |
+              quay.io/evl.ms/fullstaq-ruby:4.0-malloctrim
+              quay.io/evl.ms/fullstaq-ruby:4.0.3-malloctrim
+              quay.io/evl.ms/fullstaq-ruby:4.0-malloctrim-trixie
+          - ruby-version:   "4.0.3"
+            ruby-variant:   "malloctrim"
+            debian-image:   "trixie-slim"
+            debian-version: "13"
+            aliases: |
+              quay.io/evl.ms/fullstaq-ruby:4.0-malloctrim-slim
+              quay.io/evl.ms/fullstaq-ruby:4.0.3-malloctrim-slim
+              quay.io/evl.ms/fullstaq-ruby:4.0-malloctrim-trixie-slim
+
+          # 4.0.3 on Debian 12
+          - ruby-version:   "4.0.3"
+            ruby-variant:   "jemalloc"
+            debian-image:   "bookworm"
+            debian-version: "12"
+            aliases: |
+              quay.io/evl.ms/fullstaq-ruby:4.0-jemalloc-bookworm
+          - ruby-version:   "4.0.3"
+            ruby-variant:   "jemalloc"
+            debian-image:   "bookworm-slim"
+            debian-version: "12"
+            aliases: |
+              quay.io/evl.ms/fullstaq-ruby:4.0-jemalloc-bookworm-slim
+          - ruby-version:   "4.0.3"
+            ruby-variant:   "malloctrim"
+            debian-image:   "bookworm"
+            debian-version: "12"
+            aliases: |
+              quay.io/evl.ms/fullstaq-ruby:4.0-malloctrim-bookworm
+          - ruby-version:   "4.0.3"
+            ruby-variant:   "malloctrim"
+            debian-image:   "bookworm-slim"
+            debian-version: "12"
+            aliases: |
+              quay.io/evl.ms/fullstaq-ruby:4.0-malloctrim-bookworm-slim
+
+          # 3.4.9 on Debian 13
+          - ruby-version:   "3.4.9"
             ruby-variant:   "jemalloc"
             debian-image:   "trixie"
             debian-version: "13"
             aliases: |
               quay.io/evl.ms/fullstaq-ruby:3.4-jemalloc-trixie
-          - ruby-version:   "3.4.8"
+          - ruby-version:   "3.4.9"
             ruby-variant:   "jemalloc"
             debian-image:   "trixie-slim"
             debian-version: "13"
             aliases: |
               quay.io/evl.ms/fullstaq-ruby:3.4-jemalloc-trixie-slim
-          - ruby-version:   "3.4.8"
+          - ruby-version:   "3.4.9"
             ruby-variant:   "malloctrim"
             debian-image:   "trixie"
             debian-version: "13"
             aliases: |
               quay.io/evl.ms/fullstaq-ruby:3.4-malloctrim-trixie
-          - ruby-version:   "3.4.8"
+          - ruby-version:   "3.4.9"
             ruby-variant:   "malloctrim"
             debian-image:   "trixie-slim"
             debian-version: "13"
             aliases: |
               quay.io/evl.ms/fullstaq-ruby:3.4-malloctrim-trixie-slim
 
-          # 3.4.8 on Debian 12
-          - ruby-version:   "3.4.8"
+          # 3.4.9 on Debian 12
+          - ruby-version:   "3.4.9"
             ruby-variant:   "jemalloc"
             debian-image:   "bookworm"
             debian-version: "12"
             aliases: |
               quay.io/evl.ms/fullstaq-ruby:3.4-jemalloc
-              quay.io/evl.ms/fullstaq-ruby:3.4.8-jemalloc
+              quay.io/evl.ms/fullstaq-ruby:3.4.9-jemalloc
               quay.io/evl.ms/fullstaq-ruby:3.4-jemalloc-bookworm
-          - ruby-version:   "3.4.8"
+          - ruby-version:   "3.4.9"
             ruby-variant:   "jemalloc"
             debian-image:   "bookworm-slim"
             debian-version: "12"
             aliases: |
               quay.io/evl.ms/fullstaq-ruby:3.4-jemalloc-slim
-              quay.io/evl.ms/fullstaq-ruby:3.4.8-jemalloc-slim
+              quay.io/evl.ms/fullstaq-ruby:3.4.9-jemalloc-slim
               quay.io/evl.ms/fullstaq-ruby:3.4-jemalloc-bookworm-slim
-          - ruby-version:   "3.4.8"
+          - ruby-version:   "3.4.9"
             ruby-variant:   "malloctrim"
             debian-image:   "bookworm"
             debian-version: "12"
             aliases: |
               quay.io/evl.ms/fullstaq-ruby:3.4-malloctrim
-              quay.io/evl.ms/fullstaq-ruby:3.4.8-malloctrim
+              quay.io/evl.ms/fullstaq-ruby:3.4.9-malloctrim
               quay.io/evl.ms/fullstaq-ruby:3.4-malloctrim-bookworm
-          - ruby-version:   "3.4.8"
+          - ruby-version:   "3.4.9"
             ruby-variant:   "malloctrim"
             debian-image:   "bookworm-slim"
             debian-version: "12"
             aliases: |
               quay.io/evl.ms/fullstaq-ruby:3.4-malloctrim-slim
-              quay.io/evl.ms/fullstaq-ruby:3.4.8-malloctrim-slim
+              quay.io/evl.ms/fullstaq-ruby:3.4.9-malloctrim-slim
               quay.io/evl.ms/fullstaq-ruby:3.4-malloctrim-bookworm-slim
 
-          # 3.4.8 on Debian 11
-          - ruby-version:   "3.4.8"
+          # 3.4.9 on Debian 11
+          - ruby-version:   "3.4.9"
             ruby-variant:   "jemalloc"
             debian-image:   "bullseye"
             debian-version: "11"
             aliases: |
               quay.io/evl.ms/fullstaq-ruby:3.4-jemalloc-bullseye
-          - ruby-version:   "3.4.8"
+          - ruby-version:   "3.4.9"
             ruby-variant:   "jemalloc"
             debian-image:   "bullseye-slim"
             debian-version: "11"
             aliases: |
               quay.io/evl.ms/fullstaq-ruby:3.4-jemalloc-bullseye-slim
-          - ruby-version:   "3.4.8"
+          - ruby-version:   "3.4.9"
             ruby-variant:   "malloctrim"
             debian-image:   "bullseye"
             debian-version: "11"
             aliases: |
               quay.io/evl.ms/fullstaq-ruby:3.4-malloctrim-bullseye
-          - ruby-version:   "3.4.8"
+          - ruby-version:   "3.4.9"
             ruby-variant:   "malloctrim"
             debian-image:   "bullseye-slim"
             debian-version: "11"
             aliases: |
               quay.io/evl.ms/fullstaq-ruby:3.4-malloctrim-bullseye-slim
 
-          # 3.3.10 on Debian 13
-          - ruby-version:   "3.3.10"
+          # 3.3.11 on Debian 13
+          - ruby-version:   "3.3.11"
             ruby-variant:   "jemalloc"
             debian-image:   "trixie"
             debian-version: "13"
             aliases: |
               quay.io/evl.ms/fullstaq-ruby:3.3-jemalloc-trixie
-          - ruby-version:   "3.3.10"
+          - ruby-version:   "3.3.11"
             ruby-variant:   "jemalloc"
             debian-image:   "trixie-slim"
             debian-version: "13"
             aliases: |
               quay.io/evl.ms/fullstaq-ruby:3.3-jemalloc-trixie-slim
-          - ruby-version:   "3.3.10"
+          - ruby-version:   "3.3.11"
             ruby-variant:   "malloctrim"
             debian-image:   "trixie"
             debian-version: "13"
             aliases: |
               quay.io/evl.ms/fullstaq-ruby:3.3-malloctrim-trixie
-          - ruby-version:   "3.3.10"
+          - ruby-version:   "3.3.11"
             ruby-variant:   "malloctrim"
             debian-image:   "trixie-slim"
             debian-version: "13"
             aliases: |
               quay.io/evl.ms/fullstaq-ruby:3.3-malloctrim-trixie-slim
 
-          # 3.3.10 on Debian 12
-          - ruby-version:   "3.3.10"
+          # 3.3.11 on Debian 12
+          - ruby-version:   "3.3.11"
             ruby-variant:   "jemalloc"
             debian-image:   "bookworm"
             debian-version: "12"
             aliases: |
               quay.io/evl.ms/fullstaq-ruby:3.3-jemalloc
-              quay.io/evl.ms/fullstaq-ruby:3.3.10-jemalloc
+              quay.io/evl.ms/fullstaq-ruby:3.3.11-jemalloc
               quay.io/evl.ms/fullstaq-ruby:3.3-jemalloc-bookworm
-          - ruby-version:   "3.3.10"
+          - ruby-version:   "3.3.11"
             ruby-variant:   "jemalloc"
             debian-image:   "bookworm-slim"
             debian-version: "12"
             aliases: |
               quay.io/evl.ms/fullstaq-ruby:3.3-jemalloc-slim
-              quay.io/evl.ms/fullstaq-ruby:3.3.10-jemalloc-slim
+              quay.io/evl.ms/fullstaq-ruby:3.3.11-jemalloc-slim
               quay.io/evl.ms/fullstaq-ruby:3.3-jemalloc-bookworm-slim
-          - ruby-version:   "3.3.10"
+          - ruby-version:   "3.3.11"
             ruby-variant:   "malloctrim"
             debian-image:   "bookworm"
             debian-version: "12"
             aliases: |
               quay.io/evl.ms/fullstaq-ruby:3.3-malloctrim
-              quay.io/evl.ms/fullstaq-ruby:3.3.10-malloctrim
+              quay.io/evl.ms/fullstaq-ruby:3.3.11-malloctrim
               quay.io/evl.ms/fullstaq-ruby:3.3-malloctrim-bookworm
-          - ruby-version:   "3.3.10"
+          - ruby-version:   "3.3.11"
             ruby-variant:   "malloctrim"
             debian-image:   "bookworm-slim"
             debian-version: "12"
             aliases: |
               quay.io/evl.ms/fullstaq-ruby:3.3-malloctrim-slim
-              quay.io/evl.ms/fullstaq-ruby:3.3.10-malloctrim-slim
+              quay.io/evl.ms/fullstaq-ruby:3.3.11-malloctrim-slim
               quay.io/evl.ms/fullstaq-ruby:3.3-malloctrim-bookworm-slim
 
-          # 3.3.10 on Debian 11
-          - ruby-version:   "3.3.10"
+          # 3.3.11 on Debian 11
+          - ruby-version:   "3.3.11"
             ruby-variant:   "jemalloc"
             debian-image:   "bullseye"
             debian-version: "11"
             aliases: |
               quay.io/evl.ms/fullstaq-ruby:3.3-jemalloc-bullseye
-          - ruby-version:   "3.3.10"
+          - ruby-version:   "3.3.11"
             ruby-variant:   "jemalloc"
             debian-image:   "bullseye-slim"
             debian-version: "11"
             aliases: |
               quay.io/evl.ms/fullstaq-ruby:3.3-jemalloc-bullseye-slim
-          - ruby-version:   "3.3.10"
+          - ruby-version:   "3.3.11"
             ruby-variant:   "malloctrim"
             debian-image:   "bullseye"
             debian-version: "11"
             aliases: |
               quay.io/evl.ms/fullstaq-ruby:3.3-malloctrim-bullseye
-          - ruby-version:   "3.3.10"
+          - ruby-version:   "3.3.11"
             ruby-variant:   "malloctrim"
             debian-image:   "bullseye-slim"
             debian-version: "11"
             aliases: |
               quay.io/evl.ms/fullstaq-ruby:3.3-malloctrim-bullseye-slim
 
-          # 3.2.9 on Debian 12
-          - ruby-version:   "3.2.9"
+          # 3.2.11 on Debian 12
+          - ruby-version:   "3.2.11"
             ruby-variant:   "jemalloc"
             debian-image:   "bookworm"
             debian-version: "12"
             aliases: |
               quay.io/evl.ms/fullstaq-ruby:3.2-jemalloc-bookworm
-          - ruby-version:   "3.2.9"
+          - ruby-version:   "3.2.11"
             ruby-variant:   "jemalloc"
             debian-image:   "bookworm-slim"
             debian-version: "12"
             aliases: |
               quay.io/evl.ms/fullstaq-ruby:3.2-jemalloc-bookworm-slim
-          - ruby-version:   "3.2.9"
+          - ruby-version:   "3.2.11"
             ruby-variant:   "malloctrim"
             debian-image:   "bookworm"
             debian-version: "12"
             aliases: |
               quay.io/evl.ms/fullstaq-ruby:3.2-malloctrim-bookworm
-          - ruby-version:   "3.2.9"
+          - ruby-version:   "3.2.11"
             ruby-variant:   "malloctrim"
             debian-image:   "bookworm-slim"
             debian-version: "12"
             aliases: |
               quay.io/evl.ms/fullstaq-ruby:3.2-malloctrim-bookworm-slim
 
-          # 3.2.9 on Debian 11
-          - ruby-version:   "3.2.9"
+          # 3.2.11 on Debian 11
+          - ruby-version:   "3.2.11"
             ruby-variant:   "jemalloc"
             debian-image:   "bullseye"
             debian-version: "11"
             aliases:  |
-              quay.io/evl.ms/fullstaq-ruby:3.2.9-jemalloc
+              quay.io/evl.ms/fullstaq-ruby:3.2.11-jemalloc
               quay.io/evl.ms/fullstaq-ruby:3.2-jemalloc
-          - ruby-version:   "3.2.9"
+          - ruby-version:   "3.2.11"
             ruby-variant:   "jemalloc"
             debian-image:   "bullseye-slim"
             debian-version: "11"
             aliases: |
-              quay.io/evl.ms/fullstaq-ruby:3.2.9-jemalloc-slim
+              quay.io/evl.ms/fullstaq-ruby:3.2.11-jemalloc-slim
               quay.io/evl.ms/fullstaq-ruby:3.2-jemalloc-slim
-          - ruby-version:   "3.2.9"
+          - ruby-version:   "3.2.11"
             ruby-variant:   "malloctrim"
             debian-image:   "bullseye"
             debian-version: "11"
             aliases:  |
-              quay.io/evl.ms/fullstaq-ruby:3.2.9-malloctrim
+              quay.io/evl.ms/fullstaq-ruby:3.2.11-malloctrim
               quay.io/evl.ms/fullstaq-ruby:3.2-malloctrim
-          - ruby-version:   "3.2.9"
+          - ruby-version:   "3.2.11"
             ruby-variant:   "malloctrim"
             debian-image:   "bullseye-slim"
             debian-version: "11"
             aliases: |
-              quay.io/evl.ms/fullstaq-ruby:3.2.9-malloctrim-slim
+              quay.io/evl.ms/fullstaq-ruby:3.2.11-malloctrim-slim
               quay.io/evl.ms/fullstaq-ruby:3.2-malloctrim-slim
-
-          # 3.1.7 on Debian 11
-          - ruby-version:   "3.1.7"
-            ruby-variant:   "jemalloc"
-            debian-image:   "bullseye"
-            debian-version: "11"
-            aliases:  |
-              quay.io/evl.ms/fullstaq-ruby:3.1.7-jemalloc
-              quay.io/evl.ms/fullstaq-ruby:3.1-jemalloc
-          - ruby-version:   "3.1.7"
-            ruby-variant:   "jemalloc"
-            debian-image:   "bullseye-slim"
-            debian-version: "11"
-            aliases: |
-              quay.io/evl.ms/fullstaq-ruby:3.1.7-jemalloc-slim
-              quay.io/evl.ms/fullstaq-ruby:3.1-jemalloc-slim
-          - ruby-version:   "3.1.7"
-            ruby-variant:   "malloctrim"
-            debian-image:   "bullseye"
-            debian-version: "11"
-            aliases:  |
-              quay.io/evl.ms/fullstaq-ruby:3.1.7-malloctrim
-              quay.io/evl.ms/fullstaq-ruby:3.1-malloctrim
-          - ruby-version:   "3.1.7"
-            ruby-variant:   "malloctrim"
-            debian-image:   "bullseye-slim"
-            debian-version: "11"
-            aliases: |
-              quay.io/evl.ms/fullstaq-ruby:3.1.7-malloctrim-slim
-              quay.io/evl.ms/fullstaq-ruby:3.1-malloctrim-slim
 
     steps:
       - name: Check out the repo

--- a/README.md
+++ b/README.md
@@ -19,67 +19,73 @@ docker pull quay.io/evl.ms/fullstaq-ruby:3.4-jemalloc-slim
 Or use as base image in your `Dockerfile`:
 
 ```docker
-ARG RUBY_VERSION=3.4.8-jemalloc
+ARG RUBY_VERSION=3.4.9-jemalloc
 
 FROM quay.io/evl.ms/fullstaq-ruby:${RUBY_VERSION}-slim
 ```
 
 ## Flavors
 
-Ruby 3.4.8, 3.3.10, 3.2.9, and 3.1.7 with jemalloc and malloctrim are available. Images are built on top of Debian 11 (bullseye), 12 (bookworm), 13 (trixie):
+Ruby 4.0.3, 3.4.9, 3.3.11 and 3.2.11 with jemalloc and malloctrim are available. Images are built on top of Debian 11 (bullseye), 12 (bookworm), 13 (trixie):
 
 ```sh
+# 4.0:
+docker pull quay.io/evl.ms/fullstaq-ruby:4.0.3-jemalloc-trixie-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:4.0.3-jemalloc-trixie
+docker pull quay.io/evl.ms/fullstaq-ruby:4.0.3-jemalloc-bookworm-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:4.0.3-jemalloc-bookworm
+docker pull quay.io/evl.ms/fullstaq-ruby:4.0.3-jemalloc-bullseye-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:4.0.3-jemalloc-bullseye
+docker pull quay.io/evl.ms/fullstaq-ruby:4.0.3-malloctrim-bookworm-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:4.0.3-malloctrim-bookworm
+docker pull quay.io/evl.ms/fullstaq-ruby:4.0.3-malloctrim-bullseye-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:4.0.3-malloctrim-bullseye
+
 # 3.4:
-docker pull quay.io/evl.ms/fullstaq-ruby:3.4.8-jemalloc-trixie-slim
-docker pull quay.io/evl.ms/fullstaq-ruby:3.4.8-jemalloc-trixie
-docker pull quay.io/evl.ms/fullstaq-ruby:3.4.8-jemalloc-bookworm-slim
-docker pull quay.io/evl.ms/fullstaq-ruby:3.4.8-jemalloc-bookworm
-docker pull quay.io/evl.ms/fullstaq-ruby:3.4.8-jemalloc-bullseye-slim
-docker pull quay.io/evl.ms/fullstaq-ruby:3.4.8-jemalloc-bullseye
-docker pull quay.io/evl.ms/fullstaq-ruby:3.4.8-malloctrim-bookworm-slim
-docker pull quay.io/evl.ms/fullstaq-ruby:3.4.8-malloctrim-bookworm
-docker pull quay.io/evl.ms/fullstaq-ruby:3.4.8-malloctrim-bullseye-slim
-docker pull quay.io/evl.ms/fullstaq-ruby:3.4.8-malloctrim-bullseye
+docker pull quay.io/evl.ms/fullstaq-ruby:3.4.9-jemalloc-trixie-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:3.4.9-jemalloc-trixie
+docker pull quay.io/evl.ms/fullstaq-ruby:3.4.9-jemalloc-bookworm-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:3.4.9-jemalloc-bookworm
+docker pull quay.io/evl.ms/fullstaq-ruby:3.4.9-jemalloc-bullseye-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:3.4.9-jemalloc-bullseye
+docker pull quay.io/evl.ms/fullstaq-ruby:3.4.9-malloctrim-bookworm-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:3.4.9-malloctrim-bookworm
+docker pull quay.io/evl.ms/fullstaq-ruby:3.4.9-malloctrim-bullseye-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:3.4.9-malloctrim-bullseye
 
 # 3.3:
-docker pull quay.io/evl.ms/fullstaq-ruby:3.3.10-jemalloc-trixie-slim
-docker pull quay.io/evl.ms/fullstaq-ruby:3.3.10-jemalloc-trixie
-docker pull quay.io/evl.ms/fullstaq-ruby:3.3.10-jemalloc-bookworm-slim
-docker pull quay.io/evl.ms/fullstaq-ruby:3.3.10-jemalloc-bookworm
-docker pull quay.io/evl.ms/fullstaq-ruby:3.3.10-jemalloc-bullseye-slim
-docker pull quay.io/evl.ms/fullstaq-ruby:3.3.10-jemalloc-bullseye
-docker pull quay.io/evl.ms/fullstaq-ruby:3.3.10-malloctrim-bookworm-slim
-docker pull quay.io/evl.ms/fullstaq-ruby:3.3.10-malloctrim-bookworm
-docker pull quay.io/evl.ms/fullstaq-ruby:3.3.10-malloctrim-bullseye-slim
-docker pull quay.io/evl.ms/fullstaq-ruby:3.3.10-malloctrim-bullseye
+docker pull quay.io/evl.ms/fullstaq-ruby:3.3.11-jemalloc-trixie-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:3.3.11-jemalloc-trixie
+docker pull quay.io/evl.ms/fullstaq-ruby:3.3.11-jemalloc-bookworm-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:3.3.11-jemalloc-bookworm
+docker pull quay.io/evl.ms/fullstaq-ruby:3.3.11-jemalloc-bullseye-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:3.3.11-jemalloc-bullseye
+docker pull quay.io/evl.ms/fullstaq-ruby:3.3.11-malloctrim-bookworm-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:3.3.11-malloctrim-bookworm
+docker pull quay.io/evl.ms/fullstaq-ruby:3.3.11-malloctrim-bullseye-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:3.3.11-malloctrim-bullseye
 
 # 3.2:
-docker pull quay.io/evl.ms/fullstaq-ruby:3.2.9-jemalloc-bookworm-slim
-docker pull quay.io/evl.ms/fullstaq-ruby:3.2.9-jemalloc-bookworm
-docker pull quay.io/evl.ms/fullstaq-ruby:3.2.9-jemalloc-bullseye-slim
-docker pull quay.io/evl.ms/fullstaq-ruby:3.2.9-jemalloc-bullseye
-docker pull quay.io/evl.ms/fullstaq-ruby:3.2.9-malloctrim-bookworm-slim
-docker pull quay.io/evl.ms/fullstaq-ruby:3.2.9-malloctrim-bookworm
-docker pull quay.io/evl.ms/fullstaq-ruby:3.2.9-malloctrim-bullseye-slim
-docker pull quay.io/evl.ms/fullstaq-ruby:3.2.9-malloctrim-bullseye
-
-# 3.1:
-docker pull quay.io/evl.ms/fullstaq-ruby:3.1.7-jemalloc-bullseye-slim
-docker pull quay.io/evl.ms/fullstaq-ruby:3.1.7-jemalloc-bullseye
-docker pull quay.io/evl.ms/fullstaq-ruby:3.1.7-malloctrim-bullseye-slim
-docker pull quay.io/evl.ms/fullstaq-ruby:3.1.7-malloctrim-bullseye
+docker pull quay.io/evl.ms/fullstaq-ruby:3.2.11-jemalloc-bookworm-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:3.2.11-jemalloc-bookworm
+docker pull quay.io/evl.ms/fullstaq-ruby:3.2.11-jemalloc-bullseye-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:3.2.11-jemalloc-bullseye
+docker pull quay.io/evl.ms/fullstaq-ruby:3.2.11-malloctrim-bookworm-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:3.2.11-malloctrim-bookworm
+docker pull quay.io/evl.ms/fullstaq-ruby:3.2.11-malloctrim-bullseye-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:3.2.11-malloctrim-bullseye
 ```
 
-Latest patch versions for Ruby 3.4 on Debian 12 (bookworm) are also aliased with shortened tags including major and minor versions only: `3.4.8-jemalloc-bookworm → 3.4-jemalloc`
+Latest patch versions for Ruby 3.4 on Debian 12 (bookworm) are also aliased with shortened tags including major and minor versions only: `3.4.9-jemalloc-bookworm → 3.4-jemalloc`
 
 ```sh
-docker pull quay.io/evl.ms/fullstaq-ruby:3.4-jemalloc-slim   # Same as quay.io/evl.ms/fullstaq-ruby:3.4.8-jemalloc-bookworm-slim
-docker pull quay.io/evl.ms/fullstaq-ruby:3.4-jemalloc        # Same as quay.io/evl.ms/fullstaq-ruby:3.4.8-jemalloc-bookworm
-docker pull quay.io/evl.ms/fullstaq-ruby:3.4-malloctrim-slim # Same as quay.io/evl.ms/fullstaq-ruby:3.4.8-malloctrim-bookworm-slim
-docker pull quay.io/evl.ms/fullstaq-ruby:3.4-malloctrim      # Same as quay.io/evl.ms/fullstaq-ruby:3.4.8-malloctrim-bookworm
+docker pull quay.io/evl.ms/fullstaq-ruby:3.4-jemalloc-slim   # Same as quay.io/evl.ms/fullstaq-ruby:3.4.9-jemalloc-bookworm-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:3.4-jemalloc        # Same as quay.io/evl.ms/fullstaq-ruby:3.4.9-jemalloc-bookworm
+docker pull quay.io/evl.ms/fullstaq-ruby:3.4-malloctrim-slim # Same as quay.io/evl.ms/fullstaq-ruby:3.4.9-malloctrim-bookworm-slim
+docker pull quay.io/evl.ms/fullstaq-ruby:3.4-malloctrim      # Same as quay.io/evl.ms/fullstaq-ruby:3.4.9-malloctrim-bookworm
 ```
 
-For Ruby 3.2 and 3.1, short aliases for latest patch versions are made against Debian 11 (bullseye): `3.2.9-jemalloc-bullseye → 3.2-jemalloc`
+For Ruby 3.2 and 3.1, short aliases for latest patch versions are made against Debian 11 (bullseye): `3.2.11-jemalloc-bullseye → 3.2-jemalloc`
 
 ## Details
 


### PR DESCRIPTION
https://www.ruby-lang.org/en/news/2026/04/21/ruby-4-0-3-released/
https://www.ruby-lang.org/en/news/2026/03/11/ruby-3-4-9-released/
https://www.ruby-lang.org/en/news/2026/03/26/ruby-3-3-11-released/
https://www.ruby-lang.org/en/news/2026/03/27/ruby-3-2-11-released/

https://github.com/fullstaq-ruby/server-edition/pull/189 was merged

Ruby 3.1.7 EOL was dropped
Ruby 3.2 EOL is last release